### PR TITLE
wb-2108: release candidate

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -144,7 +144,7 @@ releases:
             wb-mqtt-gpio: 2.4.0
             wb-mqtt-mbgate: 1.0.1
             wb-mqtt-opcua: 0.1.0
-            wb-mqtt-serial: 2.22.1
+            wb-mqtt-serial: 2.22.1-wb2
             wb-mqtt-smartweb: 1.0.2
             wb-mqtt-w1: 2.1.0
             wb-rules: 2.8.0

--- a/releases.yaml
+++ b/releases.yaml
@@ -1,6 +1,6 @@
 releases:
-    wb-2107:
-        packages-common: &packages-wb-2107
+    wb-2108:
+        packages-common: &packages-wb-2108
             atecc-util: 0.4.5
             ca-certificates-contactless: '0.1'
             can-utils: 0.0+git20160831-1
@@ -114,7 +114,7 @@ releases:
             wpasupplicant: 2.3-1+deb8u4
 
         wb6/stretch:
-            <<: *packages-wb-2107
+            <<: *packages-wb-2108
 
             comerr-dev: 2.1-1.43.4-2+wb1
             e2fsck-static: 1.43.4-2+wb1
@@ -154,7 +154,7 @@ releases:
             zigbee2mqtt: 1.18.1
 
         wb5/stretch:
-            <<: *packages-wb-2107
+            <<: *packages-wb-2108
 
             linux-headers-wb2: 4.9.22-wb1
             linux-image-wb2: 4.9.22-wb1
@@ -344,11 +344,11 @@ suites:
         staging: "@staging.latest"
     wb6/stretch:
         stable: wb-2104
-        testing: wb-2107
+        testing: wb-2108
         unstable: "@unstable.latest"
     wb5/stretch:
         stable: wb-2104
-        testing: wb-2107
+        testing: wb-2108
 
 
 targets:

--- a/releases.yaml
+++ b/releases.yaml
@@ -130,8 +130,8 @@ releases:
             libwbmqtt1-2-test-utils: 2.3.0
             libwbmqtt1-dev: 1.2.0
             libwbmqtt1-test-utils: 1.2.0
-            linux-headers-wb6: 5.10.35-wb5
-            linux-image-wb6: 5.10.35-wb5
+            linux-headers-wb6: 4.9.22-wb2
+            linux-image-wb6: 4.9.22-wb2
             nodejs: 12.19.0-1nodesource1
             ss-dev: 2.0-1.43.4-2+wb1
             wb-demo-kit-configs: 1.1.4

--- a/releases.yaml
+++ b/releases.yaml
@@ -1,4 +1,7 @@
 releases:
+    # This is new release candidate. It is almost the same as wb-2107-testing
+    # but with downgraded kernel (kept from previous release)
+    # and with some wb-mqtt-serial templates rolled back to previous release version.
     wb-2108:
         packages-common: &packages-wb-2108
             atecc-util: 0.4.5
@@ -172,6 +175,181 @@ releases:
             wb-test-suite: '1.20'
             z-way-server: 2.2.5-1
 
+    # This release draft is kept for testing consistency, we don't want to
+    # downgrade linux kernel and wb-mqtt-serial.
+    # It should be removed on testing unfreeze.
+    wb-2107-testing:
+        packages-common: &packages-wb-2107-testing
+            atecc-util: 0.4.5
+            ca-certificates-contactless: '0.1'
+            can-utils: 0.0+git20160831-1
+            cmux: '1.2'
+            contactless-keyring: '0.1'
+            device-tree-compiler: 1.6.0-1
+            firmware-realtek: 20170823-1~bpo9+1
+            hostapd: 1:2.3-1+deb8u4
+            hubpower: '1.0'
+            knxd: 0.14.51-1
+            knxd-dev: 0.14.51-1
+            knxd-examples: 0.11.15-1-wb1
+            knxd-tools: 0.14.51-1
+            libateccssl: '0.1'
+            libateccssl1.1: 0.2.1
+            libfdt1: 1.6.0-1
+            libirman-dev: 0.4.4-2-wb1
+            libmosquitto-dev: 1.4.15-1+wb7-3
+            libmosquitto1: 1.4.15-1+wb7-3
+            libmosquittopp-dev: 1.4.15-1+wb7-3
+            libmosquittopp1: 1.4.15-1+wb7-3
+            libnfc-bin: 1.7.1-4
+            libnfc-dev: 1.7.1-4
+            libnfc-examples: 1.7.1-4
+            libnfc-pn53x-examples: 1.7.1-4
+            libnfc5: 1.7.1-4
+            libpthsem-compat: 2.0.8
+            libpthsem-dev: 2.0.8
+            libpthsem20: 2.0.8
+            libssl1.0.0: 1.0.2l-1~bpo8+1
+            libtcc-dev: 0.9.27~git20170226.c4c3f500-1
+            libwbmqtt: 1.7.2
+            libwbmqtt-dev: 1.7.2
+            libwbmqtt0: 1.7.2
+            libwebsockets-dev: 2.0.3-2
+            libwebsockets-test-server: 2.0.3-2
+            libwebsockets-test-server-common: 2.0.3-2
+            libwebsockets6: 1.6.1-1
+            libwebsockets8: 2.0.3-2
+            mmc-utils: 0+git20170901.37c86e60-1+wb1
+            modbus-utils: 1.2.4
+            mosquitto: 1.4.15-1+wb7-3
+            mosquitto-clients: 1.4.15-1+wb7-3
+            mosquitto-dev: 1.4.15-1+wb7-3
+            mqtt-logger: 1.8.9
+            mqtt-tools: '1.2'
+            nginx: 1.6.2-5+deb8u2~bpo70+3
+            nginx-common: 1.6.2-5+deb8u2~bpo70+3
+            nginx-doc: 1.6.2-5+deb8u2~bpo70+3
+            nginx-extras: 1.6.2-5+deb8u2~bpo70+3
+            nginx-full: 1.6.2-5+deb8u2~bpo70+3
+            nginx-light: 1.6.2-5+deb8u2~bpo70+3
+            ntp: 1:4.2.8p10+dfsg-3wb1
+            ntp-doc: 1:4.2.8p10+dfsg-3wb1
+            ntpdate: 1:4.2.8p10+dfsg-3wb1
+            python-gsmmodem-new: '1:0.11'
+            python-gspread: 1:0.4.1
+            python-json-rpc: 1.9.2.wb1
+            python-mosquitto: 1.3.4-2contactless1
+            python-mqttrpc: 1.1.1
+            python-nrf24: 1.0+1
+            python-wb-common: 1.3.3
+            python-wb-io: 1.2.3
+            python-wb-mcu-fw-updater: 1.0.8
+            python3-json-rpc: 1.9.2.wb1
+            python3-mosquitto: 1.3.4-2contactless1
+            python3-mqttrpc: 1.1.1
+            python3-wb-common: 1.3.3
+            python3-wb-mcu-fw-updater: 1.0.8
+            python3-wb-update-manager: 1.0.2
+            sensor-tools-scada-client: '1.1'
+            serial-tool: '1.0'
+            tcc: 0.9.27~git20170226.c4c3f500-1
+            u-boot-tools: 2:2017.03+wb-2
+            u-boot-tools-wb: 2:2017.03+wb-2
+            watchdog: 5.15-1
+            wb-configs: 2.1.0
+            wb-configs-stretch: 2.1.0
+            wb-daemon-watchdogs: '1.1'
+            wb-dt-overlays: '1.3'
+            wb-essential: '1.0'
+            wb-homa-ism-radio: 1.17.3
+            wb-homa-ninja-bridge: 1.9.1
+            wb-homa-rfsniffer: 1.0.9
+            wb-homa-zway: 1.0.3+wb2
+            wb-hwconf-manager: 1.40.0
+            wb-knxd-config: 1.0.1
+            wb-mcu-fw-flasher: 1.0.7
+            wb-mcu-fw-updater: 1.0.8
+            wb-mqtt-apcsnmp: '0.2'
+            wb-mqtt-bmp085: '1.2'
+            wb-mqtt-co2mon: 1.1.1
+            wb-mqtt-dac: 1.1.2
+            wb-mqtt-db-cli: 1.2.1
+            wb-mqtt-homeui: 2.5.7
+            wb-mqtt-knx: 0.1.2
+            wb-mqtt-lirc: 1.1.4
+            wb-mqtt-mhz19: '1.0'
+            wb-mqtt-sht1x: '1.0'
+            wb-mqtt-smartbus: '1.2'
+            wb-mqtt-snmp: 1.0.1
+            wb-mqtt-spl-meter: 1.1.1
+            wb-mqtt-timestamper: 1.10.1
+            wb-mqtt-zabbix: '0.2'
+            wb-mqtt-zway: 1.0.3+wb2
+            wb-rules-system: 1.6.13
+            wb-update-manager: 1.0.2
+            wb-utils: '2.3'
+            wb-zigbee2mqtt: 1.0.0
+            wpagui: 2.3-1+deb8u4
+            wpasupplicant: 2.3-1+deb8u4
+
+        wb6/stretch:
+            <<: *packages-wb-2107-testing
+
+            comerr-dev: 2.1-1.43.4-2+wb1
+            e2fsck-static: 1.43.4-2+wb1
+            e2fslibs: 1.43.4-2+wb1
+            e2fslibs-dev: 1.43.4-2+wb1
+            e2fsprogs: 1.43.4-2+wb1
+            fuse2fs: 1.43.4-2+wb1
+            libcomerr2: 1.43.4-2+wb1
+            libss2: 1.43.4-2+wb1
+            libwbmqtt1: 1.2.0
+            libwbmqtt1-2: 2.3.0
+            libwbmqtt1-2-dev: 2.3.0
+            libwbmqtt1-2-test-utils: 2.3.0
+            libwbmqtt1-dev: 1.2.0
+            libwbmqtt1-test-utils: 1.2.0
+            linux-headers-wb6: 5.10.35-wb5
+            linux-image-wb6: 5.10.35-wb5
+            nodejs: 12.19.0-1nodesource1
+            ss-dev: 2.0-1.43.4-2+wb1
+            wb-demo-kit-configs: 1.1.4
+            wb-homa-adc: 2.0.10
+            wb-homa-gpio: 2.4.0
+            wb-homa-w1: 2.1.0
+            wb-mqtt-adc: 2.0.10
+            wb-mqtt-confed: 1.2.7
+            wb-mqtt-db: 2.1.0
+            wb-mqtt-gpio: 2.4.0
+            wb-mqtt-mbgate: 1.0.1
+            wb-mqtt-opcua: 0.1.0
+            wb-mqtt-serial: 2.22.1
+            wb-mqtt-smartweb: 1.0.2
+            wb-mqtt-w1: 2.1.0
+            wb-rules: 2.8.0
+            wb-suite: '1.2'
+            wb-test-suite: '1.24'
+            z-way-server: 3.1.1
+            zigbee2mqtt: 1.18.1
+
+        wb5/stretch:
+            <<: *packages-wb-2107-testing
+
+            linux-headers-wb2: 4.9.22-wb1
+            linux-image-wb2: 4.9.22-wb1
+            mqtt-wss: '1.1'
+            wb-adc-tools-mxs: '1.0'
+            wb-homa-adc: 1.14.6
+            wb-homa-gpio: 1.19.5
+            wb-homa-w1: 1.10.1
+            wb-mqtt-confed: 1.2.2
+            wb-mqtt-db: 1.7.3
+            wb-mqtt-mbgate: 0.1.4
+            wb-mqtt-serial: 1.63.0
+            wb-rules: 1.7.1
+            wb-suite: '1.0'
+            wb-test-suite: '1.20'
+            z-way-server: 2.2.5-1
 
     wb-2104:
         packages-common: &packages-wb-2104
@@ -344,11 +522,13 @@ suites:
         staging: "@staging.latest"
     wb6/stretch:
         stable: wb-2104
-        testing: wb-2108
+        # testing is kept back in old 'wb-2107' state (with newer kernel and wb-mqtt-serial).
+        # Currently it is incompatible with new release because it will require downgrades.
+        testing: wb-2107-testing
         unstable: "@unstable.latest"
     wb5/stretch:
         stable: wb-2104
-        testing: wb-2108
+        testing: wb-2107-testing
 
 
 targets:


### PR DESCRIPTION
wb-2108 is currenly linked neither to stable nor testing in order to prevent testing downgrades.

It is almost the same as testing, only kernel and some wb-mqtt-serial templates are kept back.

wb-2108 will be available by name in repository after merging, but will not break other releases currently published.