### PR TITLE
backported wb-hwconf-manager for sim800c-ds support

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -86,7 +86,7 @@ releases:
             wb-homa-ninja-bridge: 1.9.1
             wb-homa-rfsniffer: 1.0.9
             wb-homa-zway: 1.0.3+wb2
-            wb-hwconf-manager: 1.40.2
+            wb-hwconf-manager: 1.40.0-wb1
             wb-knxd-config: 1.0.1
             wb-mcu-fw-flasher: 1.0.7
             wb-mcu-fw-updater: 1.0.10

--- a/releases.yaml
+++ b/releases.yaml
@@ -86,7 +86,7 @@ releases:
             wb-homa-ninja-bridge: 1.9.1
             wb-homa-rfsniffer: 1.0.9
             wb-homa-zway: 1.0.3+wb2
-            wb-hwconf-manager: 1.40.0
+            wb-hwconf-manager: 1.40.2
             wb-knxd-config: 1.0.1
             wb-mcu-fw-flasher: 1.0.7
             wb-mcu-fw-updater: 1.0.10


### PR DESCRIPTION
Выпускаем новый модем WBC-2G v.2
Ему нужен (но на самом деле, не критически) новый hwconf

@Boris-wb (похоже, менеджер проекта) хочет, чтобы hwconf с новым модемом попал в стейбл