### PR TITLE
WB-MRGBW-D firmware updated to 3.0.0

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -248,7 +248,7 @@ releases:
             map12eG: 2.3.5
             map12h: 2.3.2
             # WB-MRGB
-            mrgbw: 1.3.2
+            mrgbw: 3.0.0
             # WB-MCM
             mcm8: 1.3.0
             mcm8G: 1.3.0


### PR DESCRIPTION
Прошивка собрана и лежит в main

http://fw-releases.wirenboard.com/fw/by-signature/mrgbw/main/3.0.0.wbfw