### PR TITLE
wb-2201: fix MCM8 stable firmware version

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -250,8 +250,8 @@ releases:
             # WB-MRGB
             mrgbw: 3.0.0
             # WB-MCM
-            mcm8: 1.3.0
-            mcm8G: 1.3.0
+            mcm8: 1.3.1
+            mcm8G: 1.3.1
             # WB-MAO
             mao4: 2.1.0
             # WB-MAI


### PR DESCRIPTION
Это вот как раз исправление прошивки для устройств которые уже есть у клиентов и которые производство хочет запустить.