### PR TITLE
linux-image-wb6 5.10.35-wb8 => 5.10.35-wb9 (unstable-eth fixup)

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -131,9 +131,9 @@ releases:
             libwbmqtt1-3: 3.5.0
             libwbmqtt1-3-dev: 3.5.0
             libwbmqtt1-3-test-utils: 3.5.0
-            linux-headers-wb6: 5.10.35-wb8
-            linux-image-wb6: 5.10.35-wb8
-            linux-libc-dev: 5.10.35-wb8
+            linux-headers-wb6: 5.10.35-wb9
+            linux-image-wb6: 5.10.35-wb9
+            linux-libc-dev: 5.10.35-wb9
             nodejs: 12.19.0-1nodesource1
             ss-dev: 2.0-1.43.4-2+wb1
             wb-demo-kit-configs: 1.2.2


### PR DESCRIPTION
фиксы нестабильной работы lan-чипов на wb6.9

забыл ручку в dts, что приводило к странному поведению вида "один из 5 lan-чипов неправильно стартует в ядре 5.10", т.к. не срабатывала подкапотная магия с клоками/ресетом