### PR TITLE
wb-2201: fix mr2m firmware version

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -203,7 +203,7 @@ releases:
 
         firmwares:
             # WB-MR
-            mr2m: 1.15.1
+            mr2m: 1.15.0
             mr2m_k6: 1.15.3
             mr2mG: 1.16.3
             mr3: 1.16.3

--- a/releases.yaml
+++ b/releases.yaml
@@ -203,7 +203,7 @@ releases:
 
         firmwares:
             # WB-MR
-            mr2m: 1.15.0
+            mr2m: 1.15.2
             mr2m_k6: 1.15.3
             mr2mG: 1.16.3
             mr3: 1.16.3


### PR DESCRIPTION
![Снимок экрана от 2022-02-04 16-19-03](https://user-images.githubusercontent.com/66380116/152536041-9ad50342-a6b2-46a2-9239-32d443bce30c.png)

Прошивка для MR2mini-old версии 1.15.1 уже не влезает в 12K (16K FLASH - 4K bootloader) 