### PR TITLE
fws for mrwm2 temporary removed from fw-releases

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -224,7 +224,6 @@ releases:
             mrwl3: 1.16.3
             mrwl3G: 1.16.3
             mrwl3_042: 1.15.5
-            #mrwm2: 1.15.0  # not in main now
             mrwm2G: 1.16.4
             wbmwac: 1.16.4
             wbmwac_042: 1.15.6

--- a/releases.yaml
+++ b/releases.yaml
@@ -224,7 +224,7 @@ releases:
             mrwl3: 1.16.3
             mrwl3G: 1.16.3
             mrwl3_042: 1.15.5
-            mrwm2: 1.15.0
+            #mrwm2: 1.15.0  # not in main now
             mrwm2G: 1.16.4
             wbmwac: 1.16.4
             wbmwac_042: 1.15.6


### PR DESCRIPTION
предполагаю, господа эмбеддеры удалили прошивку для mrwm2 с s3
(когда это произошло - неизвестно)

если я во всём правильно разобрался - wbci всё радостно кушал из-за неработавшей логики проверки. Теперь - ругается)
=> предлагаю пока закомментить mrwm2 в релизе