### PR TITLE
wb-2201: msw3G419 stable 4.18.3

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -247,6 +247,7 @@ releases:
             msw3-49_gd: 4.16.13
             msw3-49gd_oa: 4.16.19
             msw3G49th: 4.16.19
+            msw3G419: 4.18.3
             # WB-MD
             mdm3: 2.3.0
             mdm3_042: 2.3.0


### PR DESCRIPTION
Производство случайно прошило последнюю прошивку 4.18.2 из main вместо (4.16.19) на партию v4.20A/D в которой не было звука и движения.
Позже в партии v4.20A проявилась проблема с остановкой показаний датчика движения (на самом деле всех каналов АЦП) которая была исправлена в 4.18.3.
Не стали делать 4.16.19+wb1, зашили в партию v4.20A исправленную но не очень проверенную 4.18.3.