### PR TITLE
wb-2201: add wb-test-suite-dummy package

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -107,6 +107,7 @@ releases:
             wb-mqtt-zabbix: '0.2'
             wb-mqtt-zway: 1.0.3+wb2
             wb-rules-system: 1.7.0
+            wb-test-suite-dummy: 1.9.0
             wb-update-manager: 1.2.5
             wb-utils: 3.4.1
             wb-zigbee2mqtt: 1.0.0


### PR DESCRIPTION
It replaces wb-test-suite package which was removed from the repository but may be used to build update images by older versions of build scripts.