### PR TITLE
wb-2201: mao4G 2.1.1; mrgbwG 3.0.2

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -280,13 +280,13 @@ releases:
             map6sG16: 2.3.6
             # WB-MRGB
             mrgbw: 3.0.0
-            mrgbwG: 3.0.1
+            mrgbwG: 3.0.2
             # WB-MCM
             mcm8: 1.3.1
             mcm8G: 1.3.1
             # WB-MAO
             mao4: 2.1.0
-            mao4G: 2.1.0
+            mao4G: 2.1.1
             # WB-MAI
             wb-mai-v10: 1.2.4
             # WB-MIO


### PR DESCRIPTION
Выбросы на канале VDD на GD32. Мешает проходить тесты на производстве.