### PR TITLE
wb-2207: add new release with bullseye target

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -128,9 +128,9 @@ releases:
         wb7/bullseye:
             <<: *packages-wb-2207
 
-            linux-headers-wb7: 5.10.35-wb114
-            linux-image-wb7: 5.10.35-wb114
-            linux-libc-dev: 5.10.35-wb114
+            linux-headers-wb7: 5.10.35-wb116
+            linux-image-wb7: 5.10.35-wb116
+            linux-libc-dev: 5.10.35-wb116
             u-boot-wb7: 2:2021.10+wb1.1.1
             u-boot-tools: 2:2021.10+wb1.1.1
             u-boot-tools-wb: 2:2021.10+wb1.1.1
@@ -138,9 +138,9 @@ releases:
         wb6/bullseye:
             <<: *packages-wb-2207
 
-            linux-headers-wb6: 5.10.35-wb114
-            linux-image-wb6: 5.10.35-wb114
-            linux-libc-dev: 5.10.35-wb114
+            linux-headers-wb6: 5.10.35-wb116
+            linux-image-wb6: 5.10.35-wb116
+            linux-libc-dev: 5.10.35-wb116
             u-boot-wb6: 2:2021.10+wb1.2.0~exp~feature+wb6+port+2021+10~50120~gb2763a5
             u-boot-tools: 2:2021.10+wb1.2.0~exp~feature+wb6+port+2021+10~50120~gb2763a5
             u-boot-tools-wb: 2:2021.10+wb1.2.0~exp~feature+wb6+port+2021+10~50120~gb2763a5

--- a/releases.yaml
+++ b/releases.yaml
@@ -1,4 +1,151 @@
 releases:
+    wb-2207:
+        packages-common: &packages-wb-2207
+            atecc-util: 0.4.7
+            ca-certificates-contactless: '0.1'
+            cmux: '1.2'
+            comerr-dev: 2.1-1.43.4-2+wb1
+            contactless-keyring: '0.1'
+            device-tree-compiler: 1.6.0-1
+            e2fsck-static: 1.43.4-2+wb1
+            e2fslibs-dev: 1.43.4-2+wb1
+            e2fslibs: 1.43.4-2+wb1
+            e2fsprogs: 1.43.4-2+wb1
+            emmcparm: 5.0.0
+            firmware-realtek: 20170823-1~bpo9+1
+            fuse2fs: 1.43.4-2+wb1
+            hubpower: '1.0'
+            knxd-dev: 0.14.51-1
+            knxd-examples: 0.11.15-1-wb1
+            knxd-tools: 0.14.51-1
+            knxd: 0.14.51-1
+            libateccssl1.1: 0.2.3
+            libateccssl: '0.1'
+            libcomerr2: 1.43.4-2+wb1
+            libfdt1: 1.6.0-1
+            libirman-dev: 0.4.4-2-wb1
+            libnfc-bin: 1.7.1-4
+            libnfc-dev: 1.7.1-4
+            libnfc-examples: 1.7.1-4
+            libnfc-pn53x-examples: 1.7.1-4
+            libnfc5: 1.7.1-4
+            libpthsem-compat: 2.0.8
+            libpthsem-dev: 2.0.8
+            libpthsem20: 2.0.8
+            libss2: 1.43.4-2+wb1
+            libwbmqtt-dev: 1.7.2
+            libwbmqtt0: 1.7.2
+            libwbmqtt1-3-dev: 3.7.2
+            libwbmqtt1-3-test-utils: 3.7.2
+            libwbmqtt1-3: 3.7.2
+            libwbmqtt: 1.7.2
+            modbus-utils: 1.2.4
+            mqtt-logger: 1.8.9
+            mqtt-tools: 1.3.0~exp~feature+49818+migrate+to+python3~2~gee674fb
+            nodejs: 12.19.0-1nodesource1
+            python-gsmmodem-new: '1:0.11'
+            python-gspread: 1:0.4.1
+            python-json-rpc: 1.9.2.wb1
+            python-mqttrpc: 1.1.2
+            python-nrf24: 1.0+1
+            python-wb-common: 1.4.0
+            python-wb-io: 1.2.3
+            python-wb-mcu-fw-updater: 1.3.2
+            python3-json-rpc: 1.9.2.wb1
+            python3-mqttrpc: 1.1.2
+            python3-paho-mqtt: 1.4.0-1
+            python3-umodbus: 1.0.4-1+wb1
+            python3-wb-common: 1.4.0
+            python3-wb-diag-collect: 1.2.0
+            python3-wb-mcu-fw-updater: 1.3.2
+            python3-wb-mqtt-metrics: 0.1.1
+            python3-wb-update-manager: 1.2.5
+            rapidscada: 6.0.0~beta7-2
+            sensor-tools-scada-client: '1.1'
+            serial-tool: 1.1.0
+            ss-dev: 2.0-1.43.4-2+wb1
+            tcc: 0.9.27~git20170226.c4c3f500-1
+            watchdog: 5.15-1
+            wb-configs: 3.0.0~exp~feature+49818+bullseye~15~g0c81e63
+            wb-daemon-watchdogs: '1.1'
+            wb-demo-kit-configs: 1.5.0
+            wb-diag-collect: 1.2.0
+            wb-dt-overlays: 1.5.0
+            wb-essential: 1.9.0
+            wb-homa-adc: 2.4.3
+            wb-homa-gpio: 2.8.3
+            wb-homa-ism-radio: 1.17.3
+            wb-homa-ninja-bridge: 1.9.1
+            wb-homa-rfsniffer: 1.0.9
+            wb-homa-w1: 2.2.1
+            wb-homa-zway: 1.0.3+wb2
+            wb-hwconf-manager: 1.50.0
+            wb-knxd-config: 1.1.1
+            wb-mb-explorer: 1.2.7
+            wb-mcu-fw-flasher: 1.0.8
+            wb-mcu-fw-updater: 1.3.2
+            wb-mqtt-adc: 2.4.3
+            wb-mqtt-apcsnmp: '0.2'
+            wb-mqtt-bmp085: '1.2'
+            wb-mqtt-co2mon: 1.1.1
+            wb-mqtt-confed: 1.10.0~exp~feature+50202+bullseye+confed+rebase~7~g9b4cf58
+            wb-mqtt-dac: 1.1.6
+            wb-mqtt-db-cli: 1.3.0~exp~feature+50202+bullseye~2~g32915c9
+            wb-mqtt-db: 2.5.3
+            wb-mqtt-gpio: 2.8.3
+            wb-mqtt-homeui: 2.35.1-wb1
+            wb-mqtt-iec104: 1.0.1
+            wb-mqtt-knx: 1.6.0~exp~feature+50202+bullseye~1~g9b4228e
+            wb-mqtt-lirc: 1.1.4
+            wb-mqtt-logs: 1.4.0~exp~feature+50202+bullseye~3~gc62a927
+            wb-mqtt-mbgate: 1.2.0~exp~feature+50202+bullseye~2~g709a6f4
+            wb-mqtt-metrics: 0.1.1
+            wb-mqtt-mhz19: '1.0'
+            wb-mqtt-opcua: 1.0.4
+            wb-mqtt-serial: 2.59.2-wb2
+            wb-mqtt-sht1x: '1.0'
+            wb-mqtt-smartbus: '1.2'
+            wb-mqtt-smartweb: 1.1.1
+            wb-mqtt-snmp: 1.2.0
+            wb-mqtt-spl-meter: 1.1.1
+            wb-mqtt-timestamper: 1.10.1
+            wb-mqtt-w1: 2.2.1
+            wb-mqtt-zabbix: '0.2'
+            wb-mqtt-zway: 1.0.3+wb2
+            wb-rules-system: 1.8.0
+            wb-rules: 2.12.0~exp~feature+mosquitto+socket~1~gf346539
+            wb-suite: 1.9.0
+            wb-test-suite-deps: 1.9.0
+            wb-test-suite-dummy: 1.9.0
+            wb-update-manager: 1.2.5
+            wb-utils: 3.7.0~exp~feature+50202+bullseye~1~gd3c85c3
+            wb-zigbee2mqtt: 1.1.0
+            z-way-server: 3.2.2-93-g8c133c1
+            zbw: '1.2'
+            zigbee2mqtt-1.18.1: 1.18.1
+            zigbee2mqtt: 1.25.0
+
+        wb7/bullseye:
+            <<: *packages-wb-2207
+
+            linux-headers-wb7: 5.10.35-wb114
+            linux-image-wb7: 5.10.35-wb114
+            linux-libc-dev: 5.10.35-wb114
+            u-boot-wb7: 2:2021.10+wb1.1.1
+            u-boot-tools: 2:2021.10+wb1.1.1
+            u-boot-tools-wb: 2:2021.10+wb1.1.1
+
+        wb6/bullseye:
+            <<: *packages-wb-2207
+
+            linux-headers-wb6: 5.10.35-wb114
+            linux-image-wb6: 5.10.35-wb114
+            linux-libc-dev: 5.10.35-wb114
+            u-boot-wb6: 2:2021.10+wb1.2.0~exp~feature+wb6+port+2021+10~50120~gb2763a5
+            u-boot-tools: 2:2021.10+wb1.2.0~exp~feature+wb6+port+2021+10~50120~gb2763a5
+            u-boot-tools-wb: 2:2021.10+wb1.2.0~exp~feature+wb6+port+2021+10~50120~gb2763a5
+
+
     wb-2204:
         packages-common: &packages-wb-2204
             atecc-util: 0.4.7
@@ -686,6 +833,14 @@ suites:
     all:
         pool: "@pool.latest"
         staging: "@staging.latest"
+
+    wb7/bullseye:
+        testing: wb-2207
+        unstable: wb-2207
+    wb6/bullseye:
+        testing: wb-2207
+        unstable: wb-2207
+
     wb7/stretch:
         stable: wb-2204
         testing: "@unstable.latest"
@@ -697,6 +852,7 @@ suites:
     wb5/stretch:
         stable: wb-2204
         testing: wb-2204
+
     firmwares:
         stable: _firmwares_stable
         testing: _firmwares_testing
@@ -705,6 +861,14 @@ suites:
         wb-2204: _firmwares_stable
 
 targets:
+    wb7/bullseye:
+        arch: armhf
+        distro: bullseye
+
+    wb6/bullseye:
+        arch: armhf
+        distro: bullseye
+
     wb7/stretch:
         arch: armhf
         distro: stretch

--- a/releases.yaml
+++ b/releases.yaml
@@ -66,7 +66,7 @@ releases:
             ss-dev: 2.0-1.43.4-2+wb1
             tcc: 0.9.27~git20170226.c4c3f500-1
             watchdog: 5.15-1
-            wb-configs: 3.0.0~exp~feature+49818+bullseye~15~g0c81e63
+            wb-configs: 3.0.1~exp~feature+49818+bullseye~16~g0288cc5
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.5.0
             wb-diag-collect: 1.2.0


### PR DESCRIPTION
Добавил bullseye как таргет, и сделал репозиторий, с которым получается собрать образ для обновления.

Этот PR пока никак не затронет нынешних пользователей, так как нет процедуры обновления на bullseye. Можно будет собрать FIT-образ testing и devenv.

Тут ещё лежат невлитые/недоделанные пакеты, но хочу сначала получить образ, на котором мы всё сможем обкатывать, и постепенно заменим пакеты на нормальные. Без этого не заработало бы, потому что там есть зависимости от stretch.

Из известных проблем - не работает переименование интерфейсов eth0/eth1 (их надо поменять местами). Решения не нашёл, раньше в stretch это работало благодаря патчу из debian. Вряд ли починят. Возможно, пора переименовать наши интерфейсы во что-нибудь вроде lan0/lan1.