### PR TITLE
wb-2207: upgrade homeui to 2.41.1

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -78,7 +78,7 @@ releases:
             wb-mqtt-db-cli: 1.3.0~exp~feature+50202+bullseye~2~g32915c9
             wb-mqtt-db: 2.5.5
             wb-mqtt-gpio: 2.8.4
-            wb-mqtt-homeui: 2.35.1-wb1
+            wb-mqtt-homeui: 2.41.1
             wb-mqtt-iec104: 1.0.1
             wb-mqtt-knx: 1.6.0~exp~feature+50202+bullseye~1~g9b4228e
             wb-mqtt-lirc: 1.1.4
@@ -277,7 +277,7 @@ releases:
             wb-mqtt-dac: 1.2.0
             wb-mqtt-db: 2.5.5
             wb-mqtt-gpio: 2.8.4
-            wb-mqtt-homeui: 2.40.1
+            wb-mqtt-homeui: 2.41.1
             wb-mqtt-iec104: 1.0.1
             wb-mqtt-knx: 1.9.0
             wb-mqtt-logs: 1.3.0


### PR DESCRIPTION
В bullseye-сборке вообще осталась версия homeui из прошлого stable, а в stretch просто та, что несовместима с актуальным wb-mqtt-serial (где добавились группы в списке шаблонов).

Обновил homeui до 2.41.1