### PR TITLE
wb-2207: release wb-mqtt-logs for bullseye

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -82,7 +82,7 @@ releases:
             wb-mqtt-iec104: 1.0.2
             wb-mqtt-knx: 1.6.0~exp~feature+50202+bullseye~1~g9b4228e
             wb-mqtt-lirc: 1.1.4
-            wb-mqtt-logs: 1.4.0~exp~feature+50202+bullseye~3~gc62a927
+            wb-mqtt-logs: 1.4.0
             wb-mqtt-mbgate: 1.2.0~exp~feature+50202+bullseye~2~g709a6f4
             wb-mqtt-metrics: 0.1.1
             wb-mqtt-mhz19: '1.0'
@@ -280,7 +280,7 @@ releases:
             wb-mqtt-homeui: 2.44.4
             wb-mqtt-iec104: 1.0.2
             wb-mqtt-knx: 1.9.0
-            wb-mqtt-logs: 1.3.0
+            wb-mqtt-logs: 1.3.0  # stretch-fixed, 1.4.0 build is for bullseye
             wb-mqtt-mbgate: 1.1.2
             wb-mqtt-opcua: 1.0.4
             wb-mqtt-rfblinds: '1.0'


### PR DESCRIPTION
Версия 1.4.0 собрана уже для bullseye, с соответствующими зависимостями. Для stretch теперь нужно делать бэкпорты вручную, ответвившись от `release/wb-2207/wbX-stretch`.