### PR TITLE
wb-2201: fw refu 1.0.0->1.0.1

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -852,7 +852,7 @@ releases:
             mio: 1.5.1
             # WB-REF
             ref-df: 1.0.1
-            refu: 1.0.0
+            refu: 1.0.1
 
     _firmwares_stable:
         firmwares:


### PR DESCRIPTION
решили убрать с s3 прошивку refu с багом (русский символ в device_signature; Женя в dev-чатике)
а в релизах - осталась прописана (в 2201)

=> на женкинсе релизы не собираются, т.к. проверяют доступность всех описанных прошивок