### PR TITLE
wb-2207: wb-mqtt-db-cli -> 1.3.0

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -75,7 +75,7 @@ releases:
             wb-mqtt-co2mon: 1.1.1
             wb-mqtt-confed: 1.10.0~exp~feature+50202+bullseye+confed+rebase~7~g9b4cf58
             wb-mqtt-dac: 1.2.0
-            wb-mqtt-db-cli: 1.3.0~exp~feature+50202+bullseye~2~g32915c9
+            wb-mqtt-db-cli: 1.3.0
             wb-mqtt-db: 2.5.5
             wb-mqtt-gpio: 2.8.4
             wb-mqtt-homeui: 2.44.4


### PR DESCRIPTION
wb-mqtt-db-cli для bullseye (на python3; paho вместо mosquitto)