### PR TITLE
wb-2207: release more bullseye packages

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -29,9 +29,9 @@ releases:
             libwbmqtt1-3-test-utils: 3.8.1
             libwbmqtt1-3: 3.8.1
             libwbmqtt: 1.7.2
-            modbus-utils: 1.2.4
+            modbus-utils: 1.2.5
             mqtt-logger: 1.8.9
-            mqtt-tools: 1.3.0~exp~feature+49818+migrate+to+python3~2~gee674fb
+            mqtt-tools: 1.3.0
             nodejs: 12.19.0-1nodesource1
             python-gsmmodem-new: '1:0.11'
             python-json-rpc: 1.9.2.wb1
@@ -73,14 +73,14 @@ releases:
             wb-mqtt-apcsnmp: '0.2'
             wb-mqtt-bmp085: '1.2'
             wb-mqtt-co2mon: 1.1.1
-            wb-mqtt-confed: 1.10.0~exp~feature+50202+bullseye+confed+rebase~7~g9b4cf58
+            wb-mqtt-confed: 1.10.0
             wb-mqtt-dac: 1.2.0
             wb-mqtt-db-cli: 1.3.0
             wb-mqtt-db: 2.5.5
             wb-mqtt-gpio: 2.8.4
             wb-mqtt-homeui: 2.46.1
             wb-mqtt-iec104: 1.0.2
-            wb-mqtt-knx: 1.6.0~exp~feature+50202+bullseye~1~g9b4228e
+            wb-mqtt-knx: 1.10.0
             wb-mqtt-lirc: 1.1.4
             wb-mqtt-logs: 1.4.0
             wb-mqtt-mbgate: 1.2.0~exp~feature+50202+bullseye~2~g709a6f4


### PR DESCRIPTION
Включает в себя пакеты из:

 * https://github.com/wirenboard/wb-mqtt-knx/pull/32
 * https://github.com/wirenboard/mqtt-tools/pull/2
 * https://github.com/wirenboard/modbus-utils/pull/3
 * https://github.com/wirenboard/wb-mqtt-confed/pull/29