### PR TITLE
add staging patterns list

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -794,3 +794,43 @@ targets:
         arch: [armhf, armel, amd64]
         distro: stretch
         no_auto_tests: y
+
+staging:
+    include:
+        - "comerr-dev"
+        - "e2fs*"
+        - "fuse2fs"
+        - "libcomerr2"
+        - "libss2"
+        - "ss-dev"
+
+        - "atecc-util"
+        - "ca-certificates-contactless"
+        - "cmux"
+        - "contactless-keyring"
+        - "emmcparm"
+        - "firmware-realtek"
+        - "hubpower"
+        - "knxd*"
+        - "libateccssl*"
+        - "libfdt1"
+        - "libwbmqtt*"
+        - "linux-headers-wb?"
+        - "linux-image-wb?"
+        - "linux-libc-dev"
+        - "modbus-utils"
+        - "mqtt-logger"
+        - "mqtt-tools"
+        - "nodejs"
+        - "python*"
+        - "rapidscada"
+        - "sensor-tools-scada-client"
+        - "serial-tool"
+        - "u-boot-tools-wb"
+        - "u-boot-wb?"
+        - "wb-*"
+        - "z-way-server"
+        - "zbw"
+        - "zigbee2mqtt*"
+    exclude:
+        - "*-dbgsym"


### PR DESCRIPTION
По этому списку паттернов будет собираться набор пакетов для staging-снапшотов (то есть, самые последние версии пакетов). Так мы сможем добавлять в репозиторий только те пакеты, которые нужны (в частности, это перестанет ломать сборку bullseye из-за пакетов, бэкпортированных для stretch когда-то очень давно).

Решение не самое изящное, но сходу лучше не придумалось. И оно даёт больше контроля над тем, какие пакеты у нас улетают в testing.

Зависит от https://github.com/wirenboard/wb-ci-tools/pull/13, но мерж не сломает актуальное состояние на билдсервере.