### PR TITLE
staging: add new e2fsprogs packages from bullseye

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -798,10 +798,13 @@ targets:
 staging:
     include:
         - "comerr-dev"
-        - "e2fs*"
+        - "e2fsck-static"
+        - "e2fsprogs*"
         - "fuse2fs"
-        - "libcomerr2"
+        - "libcom-err2"
+        - "libext2fs*"
         - "libss2"
+        - "logsave"
         - "ss-dev"
 
         - "atecc-util"


### PR DESCRIPTION
В новом e2fsprogs появились новые пакеты и частично переименовались старые. deb уже в репозитории, этот патч просто добавляет новые пакеты в staging.