### PR TITLE
wb-2207: update u-boot to 2021.10+wb1.4.2

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -171,9 +171,9 @@ releases:
             linux-headers-wb7: 5.10.35-wb120
             linux-image-wb7: 5.10.35-wb120
             linux-libc-dev: 5.10.35-wb120
-            u-boot-wb7: 2:2021.10+wb1.4.1
-            u-boot-tools: 2:2021.10+wb1.4.1
-            u-boot-tools-wb: 2:2021.10+wb1.4.1
+            u-boot-wb7: 2:2021.10+wb1.4.2
+            u-boot-tools: 2:2021.10+wb1.4.2
+            u-boot-tools-wb: 2:2021.10+wb1.4.2
 
         wb6/stretch:
             <<: *packages-wb-2207-armhf-stretch


### PR DESCRIPTION
https://github.com/wirenboard/u-boot-private/pull/31

У некоторых WB7 обнаружилась проблема с watchdog, который срабатывал чуть раньше ожидаемого (например, 15 с против 20 ожидаемых). Из-за этого иногда контроллер не доходит до этапа загрузки, перезагружаясь по watchdog прямо в u-boot.

Этот патч добавляет в релиз последнюю версию u-boot для wb7, где это исправлено.

Исправление проверено в офисе, помогает, вроде ничего не ломается