### PR TITLE
staging: ignore nodejs (use nodesource version from upstream)

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -705,6 +705,7 @@ staging:
         - "zigbee2mqtt*"
         - "modemmanager"
         - "network-manager"
+        - "nodejs"  # prefer nodesource version
     exclude:
         - "*-dbgsym"
         - "python*-paho-mqtt"  # ignore stretch backport


### PR DESCRIPTION
В нашем репозитории зачем-то лежит nodejs из nodesource, хотя (вроде) ничего не мешает устанавливать его напрямую. Наша версия, к тому же, не устанавливается в bullseye.

Этим коммитом я убираю nodejs из staging, при этом возможность установить его из nodesource останется (заедет в виде PR в wb-configs).