### PR TITLE
wb-2207: wb-mqtt-gpio v2.8.4->2.8.4-wb100

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -145,7 +145,7 @@ releases:
             wb-mqtt-confed: 1.8.1
             wb-mqtt-dac: 1.2.0
             wb-mqtt-db: 2.6.0
-            wb-mqtt-gpio: 2.8.4
+            wb-mqtt-gpio: 2.8.4-wb100
             wb-mqtt-homeui: 2.44.4
             wb-mqtt-iec104: 1.0.2
             wb-mqtt-knx: 1.9.0

--- a/releases.yaml
+++ b/releases.yaml
@@ -138,7 +138,7 @@ releases:
             wb-demo-kit-configs: 1.6.1
             wb-essential: 1.10.0
             wb-homa-adc: 2.5.0
-            wb-homa-gpio: 2.8.4
+            wb-homa-gpio: 2.8.4-wb100
             wb-homa-w1: 2.2.2
             wb-hwconf-manager: 1.52.7-wb101
             wb-mqtt-adc: 2.5.0


### PR DESCRIPTION
надо бекпортировать новую фильтрацию дребезга в 2207