### PR TITLE
staging: add missing NM and MM libs

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -716,8 +716,15 @@ staging:
         - "z-way-server"
         - "zbw"
         - "zigbee2mqtt*"
-        - "modemmanager"
-        - "network-manager"
+
+        - "modemmanager*"
+        - "libmm*"
+        - "gir*-modemmanager*"
+
+        - "network-manager*"
+        - "libnm*"
+        - "gir*-nm*"
+
     exclude:
         - "*-dbgsym"
         - "python*-paho-mqtt"  # ignore stretch backport


### PR DESCRIPTION
Теперь network-manager и modemmanager собираются из наших репозиториев и можно устанавливать их из staging