### PR TITLE
wb-2207: use python3-wb-test-suite-deps instead of old python2\'s

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -136,7 +136,7 @@ releases:
             rapidscada: 6.0.0~beta7-2
             ss-dev: 2.0-1.43.4-2+wb1
             wb-demo-kit-configs: 1.6.1
-            wb-essential: 1.10.0
+            wb-essential: 1.15.0
             wb-homa-adc: 2.5.0
             wb-homa-gpio: 2.8.4-wb100
             wb-homa-w1: 2.2.2
@@ -158,9 +158,9 @@ releases:
             wb-mqtt-snmp: 1.2.0
             wb-mqtt-w1: 2.2.2
             wb-rules: 2.11.4
-            wb-suite: 1.11.0
+            wb-suite: 1.15.0
             wb-test-suite-deps: 1.12.0
-            python3-wb-test-suite-deps: 1.14.0
+            python3-wb-test-suite-deps: 1.15.0
             z-way-server: 3.2.2-93-g8c133c1
             zbw: '1.2'
             zigbee2mqtt: 1.25.2


### PR DESCRIPTION
https://github.com/wirenboard/wb-metapackages/pull/17

С версии 1.11.0 не было существенных изменений, в основном всё касалось как раз test-suite.