### PR TITLE
wb-2207-bullseye-transition: update wb-update-manager to -upgrade6

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -216,9 +216,9 @@ releases:
 
     wb-2207-bullseye-transition:
         packages-common-bullseye-transition: &packages-wb-2207-bullseye-transition
-            python3-wb-update-manager: 1.2.5-upgrade5
+            python3-wb-update-manager: 1.2.5-upgrade6
             wb-mqtt-homeui: 2.44.4-upgrade1
-            wb-update-manager: 1.2.5-upgrade5
+            wb-update-manager: 1.2.5-upgrade6
 
         wb6/stretch:
             <<: *packages-wb-2207-armhf-wb6-stretch


### PR DESCRIPTION
https://github.com/wirenboard/wb-update-manager/pull/21