### PR TITLE
staging: include nodejs from our repo

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -706,6 +706,7 @@ staging:
         - "modbus-utils"
         - "mqtt-logger"
         - "mqtt-tools"
+        - "nodejs"
         - "python*"
         - "rapidscada"
         - "sensor-tools-scada-client"
@@ -728,7 +729,6 @@ staging:
     exclude:
         - "*-dbgsym"
         - "python*-paho-mqtt"  # ignore stretch backport
-        - "nodejs"  # prefer nodesource version
         - package: "*wb-update-manager"
           version: "*-upgrade*"
         - package: wb-mqtt-homeui


### PR DESCRIPTION
Использовать nodejs из нашего репозитория всё же оказывается чуть удобней. При обновлении debian со stretch на bullseye в момент, когда удаляется старый пакет `python` и устанавливается `python-is-python2`, `nodejs` из нашего репозитория удаляется из-за зависимости от `python`. Новый пакет `nodejs` зависит уже от `python3`, но поскольку его нет в `staging` (а следовательно, в `testing`), мы не можем его установить. Следом за `nodejs` удаляется `zigbee2mqtt`, что нежелательно.

Я добавил последний на сегодня пакет `nodejs` в наш пул, теперь надо добавить его в `staging`, так при обновлении до bullseye не будет удаляться `zigbee2mqtt`.