### PR TITLE
wb-2207 wb6/wb7: wb-hwconf-manager 1.52.7-wb101 -> 1.52.7-wb102

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -140,7 +140,7 @@ releases:
             wb-homa-adc: 2.5.0
             wb-homa-gpio: 2.8.4-wb100
             wb-homa-w1: 2.2.2
-            wb-hwconf-manager: 1.52.7-wb101
+            wb-hwconf-manager: 1.52.7-wb102
             wb-mqtt-adc: 2.5.0
             wb-mqtt-confed: 1.8.1
             wb-mqtt-dac: 1.2.0


### PR DESCRIPTION
бекпортируем z-wave и r3a1 (новая релюшка) для производства