### PR TITLE
bullseye-transition: update wb-update-manager to 1.2.5-upgrade8

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -216,9 +216,9 @@ releases:
 
     wb-2207-bullseye-transition:
         packages-common-bullseye-transition: &packages-wb-2207-bullseye-transition
-            python3-wb-update-manager: 1.2.5-upgrade7
+            python3-wb-update-manager: 1.2.5-upgrade8
             wb-mqtt-homeui: 2.44.4-upgrade1
-            wb-update-manager: 1.2.5-upgrade7
+            wb-update-manager: 1.2.5-upgrade8
 
         wb6/stretch:
             <<: *packages-wb-2207-armhf-wb6-stretch


### PR DESCRIPTION
https://github.com/wirenboard/wb-update-manager/pull/24