### PR TITLE
fix fast modbus  scanning in MAI6

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -614,7 +614,7 @@ releases:
             mao4G: 2.1.2
             # WB-MAI
             wb-mai-v10: 1.3.1
-            wb-mai6: 2.0.2
+            wb-mai6: 2.0.3
             # WB-MIO
             mio: 1.5.3
             # WB-REF


### PR DESCRIPTION
not critical, so not updated in stable