### PR TITLE
wb-mqtt-homeui: 2.44.4-upgrade1 → 2.44.4-upgrade2

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -217,7 +217,7 @@ releases:
     wb-2207-bullseye-transition:
         packages-common-bullseye-transition: &packages-wb-2207-bullseye-transition
             python3-wb-update-manager: 1.2.5-upgrade9
-            wb-mqtt-homeui: 2.44.4-upgrade1
+            wb-mqtt-homeui: 2.44.4-upgrade2
             wb-update-manager: 1.2.5-upgrade9
 
         wb6/stretch:


### PR DESCRIPTION
Propagate https://github.com/wirenboard/homeui/pull/377