### PR TITLE
wb-2207: update wb-mqtt-metrics to 1.1.0-wb100 (fix high load)

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -75,7 +75,7 @@ releases:
             python3-wb-common: 1.4.0
             python3-wb-diag-collect: 1.3.0-wb100
             python3-wb-mcu-fw-updater: 1.5.1-wb100
-            python3-wb-mqtt-metrics: 0.1.1
+            python3-wb-mqtt-metrics: 0.1.1-wb100
             python3-wb-update-manager: 1.2.5-wb1
             sensor-tools-scada-client: '1.1'
             serial-tool: 1.1.0
@@ -99,7 +99,7 @@ releases:
             wb-mqtt-co2mon: 1.1.1
             wb-mqtt-db-cli: 1.2.1
             wb-mqtt-lirc: 1.1.4
-            wb-mqtt-metrics: 0.1.1
+            wb-mqtt-metrics: 0.1.1-wb100
             wb-mqtt-mhz19: '1.0'
             wb-mqtt-sht1x: '1.0'
             wb-mqtt-smartbus: '1.2'


### PR DESCRIPTION
https://github.com/wirenboard/wb-mqtt-metrics/pull/6