### PR TITLE
bullseye-transition: update wb-release tool to -upgrade12

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -220,9 +220,9 @@ releases:
 
     wb-2207-bullseye-transition:
         packages-common-bullseye-transition: &packages-wb-2207-bullseye-transition
-            python3-wb-update-manager: 1.2.5-upgrade11
+            python3-wb-update-manager: 1.2.5-upgrade12
             wb-mqtt-homeui: 2.44.4-upgrade2
-            wb-update-manager: 1.2.5-upgrade11
+            wb-update-manager: 1.2.5-upgrade12
 
         wb6/stretch:
             <<: *packages-wb-2207-armhf-wb6-stretch


### PR DESCRIPTION
https://github.com/wirenboard/wb-update-manager/pull/29