### PR TITLE
pre-release fixups

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -38,9 +38,6 @@ releases:
             libwbmqtt-dev: 1.7.2
             libwbmqtt0: 1.7.2
             libwbmqtt1: 1.2.0
-            libwbmqtt1-2: 2.5.0
-            libwbmqtt1-2-dev: 2.5.0
-            libwbmqtt1-2-test-utils: 2.5.0
             libwbmqtt1-3: 3.10.0
             libwbmqtt1-3-dev: 3.10.0
             libwbmqtt1-3-test-utils: 3.10.0
@@ -74,7 +71,7 @@ releases:
             python3-json-rpc: 1.9.2.wb1
             python3-modbus-utils-rpc: 1.1.5
             python3-mosquitto: 1.3.4-2contactless1
-            python3-mqttrpc: 1.2.0
+            python3-mqttrpc: 1.2.1
             python3-paho-socket: 0.0.3
             python3-umodbus: 1.0.4-1+wb1
             python3-wb-common: 2.1.1
@@ -706,6 +703,7 @@ staging:
         - "gpiod"  # ignore stretch backport
         - "libgpiod*"  # ignore stretch backport
         - "wb-configs-stretch"
+        - "libwbmqtt1-2*"
         - package: "*wb-update-manager"
           version: "*-upgrade*"
         - package: wb-mqtt-homeui

--- a/releases.yaml
+++ b/releases.yaml
@@ -37,7 +37,6 @@ releases:
             libwbmqtt: 1.7.2
             libwbmqtt-dev: 1.7.2
             libwbmqtt0: 1.7.2
-            libwbmqtt1: 1.2.0
             libwbmqtt1-3: 3.10.0
             libwbmqtt1-3-dev: 3.10.0
             libwbmqtt1-3-test-utils: 3.10.0
@@ -703,6 +702,7 @@ staging:
         - "gpiod"  # ignore stretch backport
         - "libgpiod*"  # ignore stretch backport
         - "wb-configs-stretch"
+        - "libwbmqtt1"
         - "libwbmqtt1-2*"
         - package: "*wb-update-manager"
           version: "*-upgrade*"

--- a/releases.yaml
+++ b/releases.yaml
@@ -43,8 +43,6 @@ releases:
             libwbmqtt1-4: 4.0.0
             libwbmqtt1-4-dev: 4.0.0
             libwbmqtt1-4-test-utils: 4.0.0
-            libwbmqtt1-dev: 1.2.0
-            libwbmqtt1-test-utils: 1.2.0
             linux-libc-dev: 5.10.35-wb133
             logsave: 1.46.2-2+wb1
             modbus-utils: 1.2.7
@@ -703,6 +701,8 @@ staging:
         - "libgpiod*"  # ignore stretch backport
         - "wb-configs-stretch"
         - "libwbmqtt1"
+        - "libwbmqtt1-dev"
+        - "libwbmqtt1-test-utils"
         - "libwbmqtt1-2*"
         - package: "*wb-update-manager"
           version: "*-upgrade*"


### PR DESCRIPTION
 - do not include libwbmqtt1-2 in wb-2304 (and exclude it from staging)
 - up python3-mqttrpc to version with our Homepage to treat it as our package
 
 depends on https://github.com/wirenboard/python-mqtt-rpc/pull/10