### PR TITLE
wb-2207-transition: fix versions missed by CI

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -387,9 +387,9 @@ releases:
 
     wb-2207-bullseye-transition:
         packages-common-bullseye-transition: &packages-wb-2207-bullseye-transition
-            python3-wb-update-manager: 1.2.5-wb1-upgrade15
+            python3-wb-update-manager: 1.2.5-wb1-upgrade16
             wb-mqtt-homeui: 2.44.4-wb100-upgrade2
-            wb-update-manager: 1.2.5-wb1-upgrade15
+            wb-update-manager: 1.2.5-wb1-upgrade16
 
         wb6/stretch:
             <<: *packages-wb-2207-armhf-wb6-stretch


### PR DESCRIPTION
CI пропустил в предыдущем PR неправильные версии (фикс CI: https://github.com/wirenboard/wb-ci-tools/pull/21)