### PR TITLE
wb-2304: python3-modbus-utils-rpc v1.1.5 -> 1.1.6

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -66,7 +66,7 @@ releases:
             python-wb-mcu-fw-updater: 1.5.2
             python3-intelhex: 2.3.0-1
             python3-json-rpc: 1.9.2.wb1
-            python3-modbus-utils-rpc: 1.1.5
+            python3-modbus-utils-rpc: 1.1.6
             python3-mosquitto: 1.3.4-2contactless1
             python3-mqttrpc: 1.2.1
             python3-paho-socket: 0.0.3


### PR DESCRIPTION
починил взрывающийся modbus-scanner-rpc вот [здесь](https://github.com/wirenboard/modbus-utils-rpc/pull/12); надо в 2304