### PR TITLE
unfreeze testing on Bullseye after wb-2304

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -589,12 +589,12 @@ suites:
 
     wb7/bullseye:
         stable: wb-2304
-        testing: wb-2304
-        unstable: "@staging.latest"
+        testing: "@unstable.latest"
+        unstable: "@unstable.latest"
     wb6/bullseye:
         stable: wb-2304
-        testing: wb-2304
-        unstable: "@staging.latest"
+        testing: "@unstable.latest"
+        unstable: "@unstable.latest"
 
     wb7/stretch:
         stable: wb-2207-bullseye-transition


### PR DESCRIPTION
Теперь для testing снова используется снапшот-указатель `unstable.latest`, вместо `staging.latest` (починено в https://github.com/wirenboard/wirenboard/pull/140).

`unstable.latest` - это проверенный сборкой образа прошивки `staging.latest`.