### PR TITLE
wb-2207: update wb-configs to 2.3.4-wb102

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -247,8 +247,8 @@ releases:
             serial-tool: 1.1.0
             tcc: 0.9.27~git20170226.c4c3f500-1
             watchdog: 5.15-1
-            wb-configs-stretch: 2.3.4-wb101
-            wb-configs: 2.3.4-wb101
+            wb-configs-stretch: 2.3.4-wb102
+            wb-configs: 2.3.4-wb102
             wb-daemon-watchdogs: '1.1'
             wb-diag-collect: 1.3.0-wb101
             wb-dt-overlays: 1.6.0+wb1


### PR DESCRIPTION
https://github.com/wirenboard/wb-configs/pull/114

пакеты собраны вручную в `wbdev chroot`