### PR TITLE
wb-2304: update wb-mqtt-opcua to 1.0.6

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -123,7 +123,7 @@ releases:
             wb-mqtt-mbgate: 1.5.0
             wb-mqtt-metrics: 0.3.0
             wb-mqtt-mhz19: '1.0'
-            wb-mqtt-opcua: 1.0.4
+            wb-mqtt-opcua: 1.0.6
             wb-mqtt-rfblinds: 1.0.1
             wb-mqtt-serial: 2.81.0-wb101
             wb-mqtt-sht1x: '1.0'


### PR DESCRIPTION
Propagate bugfix https://github.com/wirenboard/wb-mqtt-opcua/pull/10 to wb-2304.