### PR TITLE
Exclude wb-homa-zway, wb-mqtt-zway, wb-mqtt-lirc

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -717,6 +717,9 @@ staging:
         - "libwbmqtt1-dev"
         - "libwbmqtt1-test-utils"
         - "libwbmqtt1-2*"
+        - "wb-homa-zway"
+        - "wb-mqtt-zway"
+        - "wb-mqtt-lirc"
         - package: "*wb-update-manager"
           version: "*-upgrade*"
         - package: wb-mqtt-homeui

--- a/releases.yaml
+++ b/releases.yaml
@@ -99,6 +99,7 @@ releases:
             wb-homa-ninja-bridge: 1.9.1
             wb-homa-rfsniffer: 1.0.9
             wb-homa-w1: 2.2.5
+            wb-homa-zway: 1.0.3+wb2
             wb-hwconf-manager: 1.57.1
             wb-knxd-config: 1.1.2
             wb-mb-explorer: 1.2.8
@@ -117,6 +118,7 @@ releases:
             wb-mqtt-homeui: 2.59.0-wb101
             wb-mqtt-iec104: 1.0.2
             wb-mqtt-knx: 1.12.0
+            wb-mqtt-lirc: 1.1.4
             wb-mqtt-logs: 1.4.1
             wb-mqtt-mbgate: 1.5.0
             wb-mqtt-metrics: 0.3.0
@@ -132,6 +134,7 @@ releases:
             wb-mqtt-timestamper: 1.10.1
             wb-mqtt-w1: 2.2.5
             wb-mqtt-zabbix: '0.2'
+            wb-mqtt-zway: 1.0.3+wb2
             wb-nm-helper: 1.23.1-wb101
             wb-rules: 2.18.1
             wb-rules-system: 1.9.4

--- a/releases.yaml
+++ b/releases.yaml
@@ -99,7 +99,6 @@ releases:
             wb-homa-ninja-bridge: 1.9.1
             wb-homa-rfsniffer: 1.0.9
             wb-homa-w1: 2.2.5
-            wb-homa-zway: 1.0.3+wb2
             wb-hwconf-manager: 1.57.1
             wb-knxd-config: 1.1.2
             wb-mb-explorer: 1.2.8
@@ -118,7 +117,6 @@ releases:
             wb-mqtt-homeui: 2.59.0-wb101
             wb-mqtt-iec104: 1.0.2
             wb-mqtt-knx: 1.12.0
-            wb-mqtt-lirc: 1.1.4
             wb-mqtt-logs: 1.4.1
             wb-mqtt-mbgate: 1.5.0
             wb-mqtt-metrics: 0.3.0
@@ -134,7 +132,6 @@ releases:
             wb-mqtt-timestamper: 1.10.1
             wb-mqtt-w1: 2.2.5
             wb-mqtt-zabbix: '0.2'
-            wb-mqtt-zway: 1.0.3+wb2
             wb-nm-helper: 1.23.1-wb101
             wb-rules: 2.18.1
             wb-rules-system: 1.9.4


### PR DESCRIPTION
```sh
root@wirenboard-A7PWH4NX ~# apt search wb-mqtt-zway
Sorting... Done
Full Text Search... Done
wb-mqtt-zway/testing 1.0.3+wb2 armhf
  Wiren Board MQTT bridge for Z-Way stack compatible with WB conventions

root@wirenboard-A7PWH4NX ~# apt install wb-mqtt-zway
…

The following packages have unmet dependencies:
 wb-mqtt-zway : Depends: libjsoncpp1 (>= 1.7.4) but it is not installable
                Depends: libwbmqtt0 but it is not going to be installed
                Depends: libjsoncpp0 but it is not installable
                Depends: libwbmqtt (>= 1.3.3)
E: Unable to correct problems, you have held broken packages.
```

Аналогично с wb-mqtt-lirc.