### PR TITLE
wb-2304: wb-utils v4.8.2-wb102 -> v4.8.2-wb103

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -144,7 +144,7 @@ releases:
             wb-test-suite-dummy: 1.17.0
             wb-update-manager: 1.3.1
             wb-update-notifier: 0.1.0
-            wb-utils: 4.8.2-wb102
+            wb-utils: 4.8.2-wb103
             wb-zigbee2mqtt: 1.2.0
             z-way-server: 4.0.2-lws16
             zbw: '1.2'


### PR DESCRIPTION
бекпортируем новую валидацию env_кеша в 2304