### PR TITLE
wb-2304: update wb-mqtt-mbgate to 1.5.4

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -31,6 +31,8 @@ releases:
             libmm-glib-dev: 1.20.0-1~bpo11+1-wb102
             libmm-glib-doc: 1.20.0-1~bpo11+1-wb102
             libmm-glib0: 1.20.0-1~bpo11+1-wb102
+            libmodbus5: 3.1.6-wb1
+            libmodbus-dev: 3.1.6-wb1
             libnm-dev: 1.40.0-1~bpo11+1-wb101
             libnm0: 1.40.0-1~bpo11+1-wb101
             libss2: 1.46.2-2+wb1
@@ -120,7 +122,7 @@ releases:
             wb-mqtt-knx: 1.12.0
             wb-mqtt-lirc: 1.1.4
             wb-mqtt-logs: 1.4.1
-            wb-mqtt-mbgate: 1.5.0
+            wb-mqtt-mbgate: 1.5.4
             wb-mqtt-metrics: 0.3.0
             wb-mqtt-mhz19: '1.0'
             wb-mqtt-opcua: 1.0.6


### PR DESCRIPTION
Propagate bugfixes:
- https://github.com/wirenboard/wb-mqtt-mbgate/pull/22
- https://github.com/wirenboard/wb-mqtt-mbgate/pull/24
- https://github.com/wirenboard/wb-mqtt-mbgate/pull/25
- https://github.com/wirenboard/libmodbus/commit/ba4a84812852022f97b773208b5e25997b5d0b1f (Fix RTU mode)