### PR TITLE
wb-2304: wb-utils v 4.8.2-wb103 -> 4.8.2-wb104

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -146,7 +146,7 @@ releases:
             wb-test-suite-dummy: 1.17.0
             wb-update-manager: 1.3.1
             wb-update-notifier: 0.1.0
-            wb-utils: 4.8.2-wb103
+            wb-utils: 4.8.2-wb104
             wb-zigbee2mqtt: 1.2.0
             z-way-server: 4.0.2-lws16
             zbw: '1.2'


### PR DESCRIPTION
бекпорт gpio-хелперов, иногда работавших некорректно, если env-кеш не подтянулся