### PR TITLE
wb-2304: wb-mqtt-homeui 2.59.0-wb103 -> 2.59.0-wb104

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -117,7 +117,7 @@ releases:
             wb-mqtt-db: 2.8.8
             wb-mqtt-db-cli: 1.4.4
             wb-mqtt-gpio: 2.11.1
-            wb-mqtt-homeui: 2.59.0-wb103
+            wb-mqtt-homeui: 2.59.0-wb104
             wb-mqtt-iec104: 1.0.2
             wb-mqtt-knx: 1.12.0
             wb-mqtt-lirc: 1.1.4


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
перетащили в 2304 вот это
https://github.com/wirenboard/homeui/pull/436