### PR TITLE
Make firmwares stable and update wb-mqtt-serial

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -127,7 +127,7 @@ releases:
             wb-mqtt-mhz19: '1.0'
             wb-mqtt-opcua: 1.0.6
             wb-mqtt-rfblinds: 1.0.1
-            wb-mqtt-serial: 2.81.0-wb101
+            wb-mqtt-serial: 2.81.0-wb102
             wb-mqtt-sht1x: '1.0'
             wb-mqtt-smartbus: '1.2'
             wb-mqtt-smartweb: 1.4.0
@@ -436,29 +436,29 @@ releases:
             wbmwac_042: 1.19.2
             wbmwacG: 1.19.2
             # WB-MS
-            m1w2: 4.22.0
-            m1w2-21: 4.22.0
-            m1w2G21: 4.22.0
-            mir: 4.22.0
-            mir64: 4.22.0
-            mir64_gd: 4.22.0
-            mai2cc: 4.22.0
-            ms-33: 4.22.0
-            msv2-4.0: 4.22.0
-            msv2-4.0_gd: 4.22.0
-            msv2G42: 4.22.1+wb1
-            msw3-48mh: 4.22.0
-            msw3-48mh30: 4.22.0
-            msw3-49: 4.22.0
-            msw3-49th30: 4.22.0
-            msw3-49-467: 4.22.0
-            msw3-49_gd: 4.22.0
-            msw3-49gd_oa: 4.22.0
-            msw3G49th: 4.22.0
-            msw3G419: 4.22.1+wb1
-            msw3G419th: 4.26.0
-            msw3Gc: 4.26.0
-            msw3G419L: 4.29.2
+            m1w2: 4.29.10
+            m1w2-21: 4.29.10
+            m1w2G21: 4.29.10
+            mir: 4.29.10
+            mir64: 4.29.10
+            mir64_gd: 4.29.10
+            mai2cc: 4.29.10
+            ms-33: 4.29.10
+            msv2-4.0: 4.29.10
+            msv2-4.0_gd: 4.29.10
+            msv2G42: 4.29.10
+            msw3-48mh: 4.29.10
+            msw3-48mh30: 4.29.10
+            msw3-49: 4.29.10
+            msw3-49th30: 4.29.10
+            msw3-49-467: 4.29.10
+            msw3-49_gd: 4.29.10
+            msw3-49gd_oa: 4.29.10
+            msw3G49th: 4.29.10
+            msw3G419: 4.29.10
+            msw3G419th: 4.29.10
+            msw3Gc: 4.29.10
+            msw3G419L: 4.29.10
             msw5G: 4.29.10
             msw5GL: 4.29.10
             msw5Gth: 4.29.10
@@ -489,16 +489,16 @@ releases:
             mrgbwG: 3.3.4
             ledG: 3.3.4
             # WB-MCM
-            mcm8: 1.4.3
-            mcm8G: 1.4.3
+            mcm8: 1.6.0
+            mcm8G: 1.6.0
             # WB-MAO
-            mao4: 2.1.2
-            mao4G: 2.1.2
+            mao4: 2.4.0
+            mao4G: 2.4.0
             # WB-MAI
             wb-mai-v10: 1.3.1
             wb-mai6: 2.0.5
             # WB-MIO
-            mio: 1.5.3
+            mio: 1.6.1
             # WB-REF
             ref-df: 1.1.0
             refu: 1.4.0

--- a/releases.yaml
+++ b/releases.yaml
@@ -489,8 +489,8 @@ releases:
             mrgbwG: 3.3.4
             ledG: 3.3.4
             # WB-MCM
-            mcm8: 1.6.0
-            mcm8G: 1.6.0
+            mcm8: 1.4.3
+            mcm8G: 1.4.3
             # WB-MAO
             mao4: 2.4.0
             mao4G: 2.4.0


### PR DESCRIPTION
wb-2304: update wb-mqtt-serial to 2.81.0-wb102
fws: make WB-MS*, WB-MCM8, WB-MAO4, WB-MIO firmwares stable

https://github.com/wirenboard/wb-mqtt-serial/pull/623