### PR TITLE
firmware stable WB-MAO4 2.4.1

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -654,8 +654,8 @@ releases:
             mcm8: 1.4.3
             mcm8G: 1.4.3
             # WB-MAO
-            mao4: 2.4.0
-            mao4G: 2.4.0
+            mao4: 2.4.1
+            mao4G: 2.4.1
             # WB-MAI
             wb-mai-v10: 1.3.1
             wb-mai6: 2.0.5
@@ -749,8 +749,8 @@ releases:
             mcm8: 1.6.0
             mcm8G: 1.6.0
             # WB-MAO
-            mao4: 2.4.0
-            mao4G: 2.4.0
+            mao4: 2.4.1
+            mao4G: 2.4.1
             # WB-MAI
             wb-mai-v10: 1.3.1
             wb-mai6: 2.0.5


### PR DESCRIPTION
https://github.com/wirenboard/wb-mao4/pull/14