### PR TITLE
wb-2307: wb-utils 4.12.0-wb101 -> 4.12.0-wb102

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -140,7 +140,7 @@ releases:
             wb-test-suite-dummy: 1.17.3
             wb-update-manager: 1.3.2
             wb-update-notifier: 0.1.0
-            wb-utils: 4.12.0-wb101
+            wb-utils: 4.12.0-wb102
             wb-zigbee2mqtt: 1.3.2
             z-way-server: 4.0.2-lws16
             zbw: '1.2'


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
бекпорт починки расширения rootfs; нужно производству
https://github.com/wirenboard/wb-utils/pull/118