### PR TITLE
add patched mmc-utils to staging and wb-2307

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -44,6 +44,7 @@ releases:
             libwbmqtt1-4-test-utils: 4.3.0
             linux-libc-dev: 5.10.35-wb142
             logsave: 1.46.2-2+wb1
+            mmc-utils: 0+git20180327.b4fe0c8c-1+wb1
             modbus-utils: 1.2.8
             modbus-utils-rpc: 1.2.2
             modemmanager: 1.20.0-1~bpo11+1-wb105
@@ -888,6 +889,8 @@ staging:
         - "flash-simcom-a76xx"
 
         - "libmodbus*"
+
+        - "mmc-utils"
 
     exclude:
         - "*-dbgsym"


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
В патче поддержка нормальной работы с rpmb, которую мы так и не отдали в апстрим.

Пакет mmc-utils я пропатчил и собрал руками, патч от прошлой версии подошёл. Проверили с ним инициализацию, работает.
