### PR TITLE
wb-2307: wb-utils: 4.12.0-wb106 -> 4.12.0-wb107; wb-2304: wb-utils: 4…

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -141,7 +141,7 @@ releases:
             wb-test-suite-dummy: 1.17.3
             wb-update-manager: 1.3.2
             wb-update-notifier: 0.1.0
-            wb-utils: 4.12.0-wb106
+            wb-utils: 4.12.0-wb107
             wb-zigbee2mqtt: 1.3.2
             z-way-server: 4.1.1-lws16
             z-way4wb: 1.4
@@ -324,7 +324,7 @@ releases:
             wb-test-suite-dummy: 1.17.0
             wb-update-manager: 1.3.1
             wb-update-notifier: 0.1.0
-            wb-utils: 4.8.2-wb105
+            wb-utils: 4.8.2-wb106
             wb-zigbee2mqtt: 1.2.0
             z-way-server: 4.0.2-lws16
             zbw: '1.2'
@@ -570,7 +570,7 @@ releases:
             <<: *packages-wb-2304-wb7-bullseye
             wb-configs: 3.13.1-70549e24-001
             wb-mqtt-homeui: 2.59.0-70549e24-001
-            wb-utils: 4.8.1-70549e24-001
+            wb-utils: 4.8.1-70549e24-002
 
     wb-2207-bullseye-transition:
         packages-common-bullseye-transition: &packages-wb-2207-bullseye-transition


### PR DESCRIPTION
….8.2-wb105 -> 4.8.2-wb106; wb-2304-70549e24: wb-utils: 4.8.1-70549e24-001 -> 4.8.1-70549e24-002

<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
Протащили [фикс серийников wb6x](https://github.com/wirenboard/wb-utils/pull/131) в 2307, 2304 и 2304-70549e24