### PR TITLE
Move WB-LED 3.4.0 firmware to stable

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -122,7 +122,7 @@ releases:
             wb-mqtt-mhz19: '1.0'
             wb-mqtt-opcua: 1.0.7
             wb-mqtt-rfblinds: 1.0.2
-            wb-mqtt-serial: 2.93.3-wb100
+            wb-mqtt-serial: 2.93.3-wb101
             wb-mqtt-sht1x: '1.0'
             wb-mqtt-smartbus: '1.2'
             wb-mqtt-smartweb: 1.4.0
@@ -666,9 +666,9 @@ releases:
             map6sG16: 2.6.2         #таргет не проходит стенд калибровки на прошивке 2.7.1
             map6semG16: 2.7.1
             # WB-MRGB
-            mrgbw: 3.3.4
-            mrgbwG: 3.3.4
-            ledG: 3.3.4
+            mrgbw: 3.3.4        # на данном таргете на версиях старше 3.3.4 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
+            mrgbwG: 3.4.0
+            ledG: 3.4.0
             # WB-MCM
             mcm8: 1.6.0
             mcm8G: 1.6.0


### PR DESCRIPTION
https://github.com/wirenboard/wb-mqtt-serial/pull/646