### PR TITLE
wb-2307: update wb-mqtt-homeui to 2.75.11

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -113,7 +113,7 @@ releases:
             wb-mqtt-db: 2.8.9
             wb-mqtt-db-cli: 1.4.5
             wb-mqtt-gpio: 2.12.1
-            wb-mqtt-homeui: 2.75.6
+            wb-mqtt-homeui: 2.75.11
             wb-mqtt-iec104: 1.1.1
             wb-mqtt-knx: 1.12.1
             wb-mqtt-logs: 1.4.2


### PR DESCRIPTION
Bugfixes:
* https://github.com/wirenboard/homeui/pull/471
* https://github.com/wirenboard/homeui/pull/475
* https://github.com/wirenboard/homeui/pull/476
* https://github.com/wirenboard/homeui/pull/477
* https://github.com/wirenboard/homeui/pull/478