### PR TITLE
wb-2310: remove python3-modbus-utils-rpc

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -62,7 +62,6 @@ releases:
             python3-aioblescan: 0.2.14
             python3-intelhex: 2.3.0-1
             python3-json-rpc: 1.9.2.wb1
-            python3-modbus-utils-rpc: 1.1.7
             python3-mosquitto: 1.3.4-2contactless1
             python3-mqttrpc: 1.2.2
             python3-paho-socket: 0.0.3-1


### PR DESCRIPTION
It is replaced by modbus-utils-rpc
