### PR TITLE
wb-2310: wb-mqtt-serial 2.105.0 -> 2.106.3

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -122,7 +122,7 @@ releases:
             wb-mqtt-mhz19: '1.0'
             wb-mqtt-opcua: 1.1.1
             wb-mqtt-rfblinds: 1.0.2
-            wb-mqtt-serial: 2.105.0
+            wb-mqtt-serial: 2.106.3
             wb-mqtt-sht1x: '1.0'
             wb-mqtt-smartbus: '1.2'
             wb-mqtt-smartweb: 1.4.0


### PR DESCRIPTION
```
wb-mqtt-serial (2.106.3) 
  * Fix port reopen after connection errors
wb-mqtt-serial (2.106.2)
  * Add NEVA MT 324 third and forth tariffs reading
wb-mqtt-serial (2.106.1)
  * Fix fast modbus packets reading error
wb-mqtt-serial (2.106.0)
 * Add new template for Komfovent

```
Считаю, 2.106.1 и 2.106.3 очень важными, но смысл делать бэкпорт из-за промежуточных шаблонов не вижу. Поэтому просто двигаю версию
