### PR TITLE
wb-2310: update wb-mqtt-gpio to 2.12.3

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -94,7 +94,7 @@ releases:
             wb-essential: 1.18.0
             wb-firmware-realtek: 1.0.2
             wb-homa-adc: 2.6.3
-            wb-homa-gpio: 2.12.2
+            wb-homa-gpio: 2.12.3
             wb-homa-ism-radio: 1.17.3
             wb-homa-rfsniffer: 1.0.9
             wb-homa-w1: 2.2.6
@@ -112,7 +112,7 @@ releases:
             wb-mqtt-dac: 1.2.3
             wb-mqtt-db: 2.8.9
             wb-mqtt-db-cli: 1.4.5
-            wb-mqtt-gpio: 2.12.2
+            wb-mqtt-gpio: 2.12.3
             wb-mqtt-homeui: 2.75.12
             wb-mqtt-iec104: 1.1.2
             wb-mqtt-knx: 1.12.2


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-mqtt-gpio/pull/56