### PR TITLE
wb-2310: wb-ec-firmware 1.1.0 -> 1.1.1

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -90,7 +90,7 @@ releases:
             wb-device-manager: 1.6.0
             wb-diag-collect: 1.8.2
             wb-dt-overlays: 1.6.0+wb1
-            wb-ec-firmware: 1.1.0
+            wb-ec-firmware: 1.1.1
             wb-essential: 1.18.0
             wb-firmware-realtek: 1.0.2
             wb-homa-adc: 2.6.3


### PR DESCRIPTION
https://github.com/wirenboard/wb-embedded-controller/pull/24