### PR TITLE
temporarily disable firmware publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
 publishRelease releasesFilename: 'releases.yaml',
                aptlyConfig: 'release-aptly-config',
+               hasFirmwares: false,
                triggerCheckStaging: true


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
Временно сломалась сборка репозитория с прошивками, отключаю её, чтобы софт не тормозить