### PR TITLE
WB-MAO4: testing firmware 2.4.3 -> 2.4.4 (#19)

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -945,8 +945,8 @@ releases:
             mcm8: 1.6.3
             mcm8G: 1.6.3
             # WB-MAO
-            mao4: 2.4.3
-            mao4G: 2.4.3
+            mao4: 2.4.4
+            mao4G: 2.4.4
             # WB-MAI
             wb-mai-v10: 1.3.1
             wb-mai6: 2.0.5


### PR DESCRIPTION
https://github.com/wirenboard/wb-mao4/pull/19
https://github.com/wirenboard/libwbmcu-periph/pull/168

