### PR TITLE
wb-2310: fix 1-Wire to DI mode switch on wb74+

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -98,7 +98,7 @@ releases:
             wb-homa-ism-radio: 1.17.3
             wb-homa-rfsniffer: 1.0.9
             wb-homa-w1: 2.2.6
-            wb-hwconf-manager: 1.58.3
+            wb-hwconf-manager: 1.58.4
             wb-knxd-config: 1.1.2
             wb-mb-explorer: 1.2.8
             wb-mcu-fw-flasher: 1.2.1
@@ -159,8 +159,8 @@ releases:
         wb7/bullseye: &packages-wb-2310-wb7-bullseye
             <<: *packages-wb-2310
 
-            linux-headers-wb7: 5.10.35-wb153
-            linux-image-wb7: 5.10.35-wb153
+            linux-headers-wb7: 5.10.35-wb155
+            linux-image-wb7: 5.10.35-wb155
             mplc4-wirenboard7: 1.3.3.15223
             u-boot-tools-wb: 2:2021.10+wb1.7.0
             u-boot-wb7: 2:2021.10+wb1.7.0


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-hwconf-manager/pull/111/
https://github.com/wirenboard/linux/pull/164/

Ещё плюсом https://github.com/wirenboard/linux/pull/162/, там фикс определения microsd в бутлете на wb7.3+