### PR TITLE
WB-LED: testing firmware 3.4.1 -> 3.4.2 (#73)

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -939,8 +939,8 @@ releases:
             map6semG16: 2.7.5
             # WB-MRGB
             mrgbw: 3.3.4        # на данном таргете на версиях старше 3.3.4 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
-            mrgbwG: 3.4.1
-            ledG: 3.4.1
+            mrgbwG: 3.4.2
+            ledG: 3.4.2
             # WB-MCM
             mcm8: 1.6.3
             mcm8G: 1.6.3


### PR DESCRIPTION
https://github.com/wirenboard/wb-mrgb/pull/73