### PR TITLE
wb-2310: wb-nm-helper, wb-mqtt-homeui update

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -113,7 +113,7 @@ releases:
             wb-mqtt-db: 2.8.9
             wb-mqtt-db-cli: 1.4.5
             wb-mqtt-gpio: 2.12.3
-            wb-mqtt-homeui: 2.75.14-wb100
+            wb-mqtt-homeui: 2.75.14-wb101
             wb-mqtt-iec104: 1.1.2
             wb-mqtt-knx: 1.12.2
             wb-mqtt-logs: 1.4.3
@@ -130,7 +130,7 @@ releases:
             wb-mqtt-urri: 1.0.7
             wb-mqtt-w1: 2.2.6
             wb-mqtt-zabbix: '0.2'
-            wb-nm-helper: 1.29.5
+            wb-nm-helper: 1.31.1
             wb-rules: 2.18.6
             wb-rules-system: 1.9.6
             wb-suite: 1.17.4


### PR DESCRIPTION
* wb-nm-helper 1.29.5 -> 1.31.1
* wb-mqtt-homeui: 2.75.14-wb100 -> 2.75.14-wb101

https://github.com/wirenboard/homeui/pull/495
Соответсвующие доработки в wb-nm-helper заехали в 1.31.0, но раз уж поднимать версию, то и багфикс работы со старыми /etc/network/interfaces тоже подтянул

