### PR TITLE
staging: remove wb-cloud-agent designed for wb-2207

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1126,3 +1126,6 @@ staging:
           version: "*-upgrade*"
         - package: wb-mqtt-homeui
           version: "*-upgrade*"
+        - "wb-cloud-agent-curl"  # used only in stretch
+        - package: wb-cloud-agent
+          version: "*-wb*"  # ignore stretch backport


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
В staging попали пакеты, собранные для wb-2207, тут их явно исключаю