### PR TITLE
wb-2310: update wb-cloud-agent to 1.2.8

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -86,7 +86,7 @@ releases:
             u-boot-tools-wb: 2:2021.10+wb1.7.0
             wb-ble-tesliot: 1.1.1
             wb-cc2652p-flasher: 1.0.0
-            wb-cloud-agent: 1.2.5
+            wb-cloud-agent: 1.2.8
             wb-configs: 3.19.3
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.6.3


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-cloud-agent/pull/9
https://github.com/wirenboard/wb-cloud-agent/pull/8
https://github.com/wirenboard/wb-cloud-agent/pull/7