### PR TITLE
wb-2307-cb8ea449: update wb-mqtt-homeui to 2.75.6-cb8ea449-wb101

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -522,7 +522,7 @@ releases:
         wb7/bullseye:
             <<: *packages-wb-2307-wb7-bullseye
             mplc4-oni-plc-w: 1.3.3.15735
-            wb-mqtt-homeui: 2.75.6-cb8ea449-wb100
+            wb-mqtt-homeui: 2.75.6-cb8ea449-wb101
             wb-utils: 4.12.0-wb105-cb8ea449-1
             wb-mqtt-confed: 1.14.0
 


### PR DESCRIPTION
* https://github.com/wirenboard/homeui/pull/515