### PR TITLE
wb-cloud-agent version bump

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -837,7 +837,7 @@ releases:
             rapidscada: 6.0.2-1
             ss-dev: 2.0-1.43.4-2+wb1
             telegraf-wb-cloud-agent: 1.28.4
-            wb-cloud-agent: 1.2.5-wb101
+            wb-cloud-agent: 1.2.5-wb102
             wb-cloud-agent-curl: 1.2.5-wb101
             wb-demo-kit-configs: 1.6.1
             wb-essential: 1.15.0


### PR DESCRIPTION
Бэкпорт https://github.com/wirenboard/wb-cloud-agent/pull/13
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
