### PR TITLE
wb-cloud-agent version bump (wb-2401)

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -90,7 +90,7 @@ releases:
             u-boot-tools-wb: 2:2021.10+wb1.7.1
             wb-ble-tesliot: 1.1.1
             wb-cc2652p-flasher: 1.0.0
-            wb-cloud-agent: 1.2.8
+            wb-cloud-agent: 1.3.1
             wb-configs: 3.22.1
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.6.3


### PR DESCRIPTION
Бэкпорт https://github.com/wirenboard/wb-cloud-agent/pull/13
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
