### PR TITLE
wb-2207: wb-cloud-agent-curl 1.2.5-wb101 → 1.2.5-wb102

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -838,7 +838,7 @@ releases:
             ss-dev: 2.0-1.43.4-2+wb1
             telegraf-wb-cloud-agent: 1.28.4
             wb-cloud-agent: 1.2.5-wb102
-            wb-cloud-agent-curl: 1.2.5-wb101
+            wb-cloud-agent-curl: 1.2.5-wb102
             wb-demo-kit-configs: 1.6.1
             wb-essential: 1.15.0
             wb-homa-adc: 2.5.0


### PR DESCRIPTION
Забыли поднять тут https://github.com/wirenboard/wb-releases/pull/571