### PR TITLE
wb-2207-bullseye-transition: update homeui to -upgrade3

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -928,7 +928,7 @@ releases:
     wb-2207-bullseye-transition:
         packages-common-bullseye-transition: &packages-wb-2207-bullseye-transition
             python3-wb-update-manager: 1.2.5-wb1-upgrade18
-            wb-mqtt-homeui: 2.44.4-wb102-upgrade2
+            wb-mqtt-homeui: 2.44.4-wb102-upgrade3
             wb-update-manager: 1.2.5-wb1-upgrade18
 
         wb6/stretch:


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/homeui/pull/516