### PR TITLE
WB-LED make 3.4.3 firmware stable

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1023,8 +1023,8 @@ releases:
             map6semG16: 2.8.1
             # WB-MRGB
             mrgbw: 3.3.4        # на данном таргете на версиях старше 3.3.4 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
-            mrgbwG: 3.4.2
-            ledG: 3.4.2
+            mrgbwG: 3.4.3
+            ledG: 3.4.3
             # WB-MCM
             mcm8: 1.6.4
             mcm8G: 1.6.4


### PR DESCRIPTION
https://github.com/wirenboard/wb-mrgb/pull/75