### PR TITLE
wb-2401: wb-demo-kit-configs 1.6.3 → 1.6.4

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -93,7 +93,7 @@ releases:
             wb-cloud-agent: 1.3.1
             wb-configs: 3.22.1
             wb-daemon-watchdogs: '1.1'
-            wb-demo-kit-configs: 1.6.3
+            wb-demo-kit-configs: 1.6.4
             wb-device-manager: 1.6.1
             wb-diag-collect: 1.8.6
             wb-dt-overlays: 1.6.0+wb1


### PR DESCRIPTION
В https://github.com/wirenboard/wb-releases/pull/584 попало в wb-2310, вместо wb-2401.

```sh
cat releases.yaml | yq '.releases."wb-2401"."wb7/bullseye"."wb-demo-kit-configs"'
"1.6.4"
```