### PR TITLE
WB-MAI6: make 2.0.8 fw stable

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1034,8 +1034,8 @@ releases:
             mao4G: 2.4.4
             # WB-MAI
             wb-mai-v10: 1.3.1
-            wb-mai6: 2.0.7
-            wb-mai6-15: 2.0.7
+            wb-mai6: 2.0.8
+            wb-mai6-15: 2.0.8
             # WB-MIO
             mio: 1.6.3
             # WB-REF


### PR DESCRIPTION
https://github.com/wirenboard/wb-releases/pull/576
