### PR TITLE
wb-2401: wb-mcu-fw-updater v1.9.3->v1.10.12; wb-2404: wb-mcu-fw-updat…

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -72,7 +72,7 @@ releases:
             python3-paho-socket: 0.0.3-1
             python3-umodbus: 1.0.4-1+wb1
             python3-wb-common: 2.1.2
-            python3-wb-mcu-fw-updater: 1.10.11
+            python3-wb-mcu-fw-updater: 1.10.12
             python3-wb-mqtt-metrics: 0.3.3
             python3-wb-nm-helper: 1.33.1
             python3-wb-test-suite-deps: 1.18.4
@@ -109,7 +109,7 @@ releases:
             wb-knxd-config: 1.1.2
             wb-mb-explorer: 1.2.8
             wb-mcu-fw-flasher: 1.3.2
-            wb-mcu-fw-updater: 1.10.11
+            wb-mcu-fw-updater: 1.10.12
             wb-modbus-ext-scanner: 1.2.3
             wb-mqtt-adc: 2.6.5
             wb-mqtt-apcsnmp: '0.2'
@@ -243,7 +243,7 @@ releases:
             python3-umodbus: 1.0.4-1+wb1
             python3-wb-common: 2.1.2
             python3-wb-diag-collect: 1.8.6
-            python3-wb-mcu-fw-updater: 1.9.3
+            python3-wb-mcu-fw-updater: 1.10.12
             python3-wb-mqtt-metrics: 0.3.1
             python3-wb-nm-helper: 1.32.0
             python3-wb-test-suite-deps: 1.18.3
@@ -280,7 +280,7 @@ releases:
             wb-knxd-config: 1.1.2
             wb-mb-explorer: 1.2.8
             wb-mcu-fw-flasher: 1.3.1
-            wb-mcu-fw-updater: 1.9.3
+            wb-mcu-fw-updater: 1.10.12
             wb-modbus-ext-scanner: 1.2.2
             wb-mqtt-adc: 2.6.4
             wb-mqtt-apcsnmp: '0.2'


### PR DESCRIPTION
…er v1.10.11->v1.10.12

<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->

господа ембеддеры хотят в 2401 изменения в упдатере, касательно предложений обновить бутлоадер (в связи с wb-mwac 2.0)

я посмотрел - нужны +- все => просто перетащил релизную веточку => без суффиксов