### PR TITLE
wb-2404: drop sensor-tools-scada-client

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1,5 +1,4 @@
 releases:
-
     wb-2404:
         packages-common: &packages-wb-2404
             atecc-util: 0.4.11
@@ -79,7 +78,6 @@ releases:
             python3-wb-update-manager: 1.3.2
             python3-zpl: 0.1.10-wb101
             rapidscada: 6.2.1-1
-            sensor-tools-scada-client: '1.1'
             serial-tool: 1.2.0
             sigrok-cli: 0.7.2-1
             ss-dev: 2.0-1.46.2-2+wb1
@@ -1425,7 +1423,6 @@ staging:
         - "nodejs"
         - "python*"
         - "rapidscada"
-        - "sensor-tools-scada-client"
         - "serial-tool"
         - "tailscale"
         - "telegraf-wb-cloud-agent"


### PR DESCRIPTION
```
The following packages have unmet dependencies:
 sensor-tools-scada-client : Depends: python-mqttrpc but it is not installable
E: Unable to correct problems, you have held broken packages.
```