### PR TITLE
wb-2404: wb-mqtt-logs 1.4.4 → 1.4.6

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -120,7 +120,7 @@ releases:
             wb-mqtt-homeui: 2.82.1
             wb-mqtt-iec104: 1.1.5
             wb-mqtt-knx: 1.12.7
-            wb-mqtt-logs: 1.4.4
+            wb-mqtt-logs: 1.4.6
             wb-mqtt-mbgate: 1.6.0
             wb-mqtt-metrics: 0.3.3
             wb-mqtt-opcua: 1.1.2


### PR DESCRIPTION
* https://github.com/wirenboard/wb-mqtt-logs/pull/18
* https://github.com/wirenboard/wb-mqtt-logs/pull/19