### PR TITLE
wb8/bullseye: bump wb-ec-firmware version

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -247,7 +247,7 @@ releases:
             wb-device-manager: 1.7.0
             wb-diag-collect: 1.8.6
             wb-dt-overlays: 1.7.0
-            wb-ec-firmware: 1.2.1
+            wb-ec-firmware: 1.3.1
             wb-essential: 1.18.5
             wb-firmware-realtek: 1.0.3
             wb-knxd-config: 1.1.3


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
с печалью заметил, что wb8 не прошивает EC на инициаллизации