### PR TITLE
wb-2404 updates

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -77,10 +77,10 @@ releases:
             python3-wb-update-manager: 1.3.2
             python3-zpl: 0.1.10-wb101
             rapidscada: 6.2.1-1
-            serial-tool: 1.2.0
+            serial-tool: 1.2.1
             sigrok-cli: 0.7.2-1
             ss-dev: 2.0-1.46.2-2+wb1
-            tailscale: 1.66.1
+            tailscale: 1.66.4
             task-wb-base-system: 1.18.6
             task-wb-common-pkgs: 1.18.6
             telegraf-wb-cloud-agent: 1.29.1
@@ -107,12 +107,12 @@ releases:
             wb-mb-explorer: 1.2.8
             wb-mcu-fw-flasher: 1.3.2
             wb-mcu-fw-updater: 1.10.12
-            wb-modbus-ext-scanner: 1.2.3
+            wb-modbus-ext-scanner: 1.2.4
             wb-mqtt-adc: 2.6.5
             wb-mqtt-apcsnmp: '0.2'
             wb-mqtt-bmp085: '1.2'
             wb-mqtt-co2mon: 1.1.1
-            wb-mqtt-confed: 1.14.6
+            wb-mqtt-confed: 1.14.7
             wb-mqtt-dac: 1.2.4
             wb-mqtt-db: 2.8.13
             wb-mqtt-db-cli: 1.4.5
@@ -133,7 +133,7 @@ releases:
             wb-mqtt-w1: 2.2.10
             wb-mqtt-zabbix: '0.2'
             wb-nm-helper: 1.33.3
-            wb-rules: 2.20.1
+            wb-rules: 2.20.8
             wb-rules-system: 1.11.0
             wb-suite: 1.18.6
             wb-test-suite: '1.20'
@@ -232,9 +232,9 @@ releases:
             python3-wb-test-suite-deps: 1.18.6
             python3-wb-update-manager: 1.3.2
             python3-zpl: 0.1.10-wb101
-            serial-tool: 1.2.0
+            serial-tool: 1.2.1
             ss-dev: 2.0-1.46.2-2+wb1
-            tailscale: 1.66.1
+            tailscale: 1.66.4
             task-wb-base-system: 1.18.6
             task-wb-common-pkgs: 1.18.6
             telegraf-wb-cloud-agent: 1.29.1
@@ -254,10 +254,10 @@ releases:
             wb-mb-explorer: 1.2.8
             wb-mcu-fw-flasher: 1.3.2
             wb-mcu-fw-updater: 1.10.12
-            wb-modbus-ext-scanner: 1.2.3
+            wb-modbus-ext-scanner: 1.2.4
             wb-mqtt-adc: 2.6.5
             wb-mqtt-bmp085: '1.2'
-            wb-mqtt-confed: 1.14.6
+            wb-mqtt-confed: 1.14.7
             wb-mqtt-dac: 1.2.4
             wb-mqtt-db: 2.8.13
             wb-mqtt-db-cli: 1.4.5
@@ -276,7 +276,7 @@ releases:
             wb-mqtt-urri: 1.2.1
             wb-mqtt-w1: 2.2.10
             wb-nm-helper: 1.33.3
-            wb-rules: 2.20.1
+            wb-rules: 2.20.8
             wb-rules-system: 1.11.0
             wb-suite: 1.18.6
             wb-test-suite: '1.20'


### PR DESCRIPTION
Major updates:
* https://github.com/wirenboard/wb-mqtt-confed/pull/55
* https://github.com/wirenboard/wb-rules/pull/111 

Minor updates:
* https://github.com/wirenboard/wb-rules/pull/105
* https://github.com/wirenboard/wb-rules/pull/107
* https://github.com/wirenboard/wb-rules/pull/106
* https://github.com/wirenboard/wb-rules/pull/108
* https://github.com/wirenboard/wb-rules/pull/109
* https://github.com/wirenboard/wb-rules/pull/110 
* https://github.com/wirenboard/serial_tool/pull/4
* https://github.com/wirenboard/wb-modbus-ext-scanner/pull/16
* https://github.com/tailscale/tailscale/releases