### PR TITLE
wb-2404: tailscale 1.66.4 → 1.68.0

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -80,7 +80,7 @@ releases:
             serial-tool: 1.2.1
             sigrok-cli: 0.7.2-1
             ss-dev: 2.0-1.46.2-2+wb1
-            tailscale: 1.66.4
+            tailscale: 1.68.0
             task-wb-base-system: 1.18.6
             task-wb-common-pkgs: 1.18.6
             telegraf-wb-cloud-agent: 1.29.1
@@ -234,7 +234,7 @@ releases:
             python3-zpl: 0.1.10-wb101
             serial-tool: 1.2.1
             ss-dev: 2.0-1.46.2-2+wb1
-            tailscale: 1.66.4
+            tailscale: 1.68.0
             task-wb-base-system: 1.18.6
             task-wb-common-pkgs: 1.18.6
             telegraf-wb-cloud-agent: 1.29.1


### PR DESCRIPTION
https://github.com/tailscale/tailscale/releases/tag/v1.68.0