### PR TITLE
wb-2404 wb8: add temporary wb-gsm fixup

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -295,7 +295,7 @@ releases:
 
             wb-hwconf-manager: 1.60.0
             wb-configs: 3.23.1
-            wb-utils: 4.21.1
+            wb-utils: 4.21.2~exp~tmp+vdromanov+wb+2404+wb8+wbgsm~2~g462b06b
 
 
     wb-2401:


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
фикс модема для wb8; обсудили внутри => в релизе для wb8 будет пока так