### PR TITLE
wb8/wb-2404: wb-mqtt-homeui v2.82.1-wb101 -> v2.82.1-wb103

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -261,7 +261,7 @@ releases:
             wb-mqtt-db: 2.8.13
             wb-mqtt-db-cli: 1.4.5
             wb-mqtt-gpio: 2.13.1
-            wb-mqtt-homeui: 2.82.1-wb101
+            wb-mqtt-homeui: 2.82.1-wb103
             wb-mqtt-iec104: 1.1.5
             wb-mqtt-knx: 1.12.8
             wb-mqtt-logs: 1.4.6


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
внутри - конфиг для wb8 и механизм подсовывания правильного board-конфига