### PR TITLE
wb8: backport neer-modem fixups

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -285,10 +285,10 @@ releases:
             wb-update-notifier: 0.1.0
             wb-zigbee2mqtt: 1.3.5
 
-            linux-headers-wb8: 6.8.0-wb8~exp~feature+wb8+6+8~113~gc9270ac17a6c
-            linux-image-wb8: 6.8.0-wb8~exp~feature+wb8+6+8~113~gc9270ac17a6c
-            linux-libc-dev: 6.8.0-wb8~exp~feature+wb8+6+8~113~gc9270ac17a6c
-            wb-bootlet-wb8x: 6.8.0-wb8~exp~feature+wb8+6+8~113~gc9270ac17a6c-fs1.3.1-deb11-202405141557
+            linux-headers-wb8: 6.8.0-wb10~exp~feature+wb8+6+8~118~geff941b5c61e
+            linux-image-wb8: 6.8.0-wb10~exp~feature+wb8+6+8~118~geff941b5c61e
+            linux-libc-dev: 6.8.0-wb10~exp~feature+wb8+6+8~118~geff941b5c61e
+            wb-bootlet-wb8x: 6.8.0-wb10~exp~feature+wb8+6+8~118~geff941b5c61e-fs1.3.1-deb11-202405141557
 
             u-boot-wb8: 2:2024.01+wb1.0.0
             u-boot-tools: 2:2024.01+wb1.0.0
@@ -296,7 +296,7 @@ releases:
 
             wb-hwconf-manager: 1.60.0
             wb-configs: 3.23.1
-            wb-utils: 4.21.2~exp~tmp+vdromanov+wb+2404+wb8+wbgsm~2~g462b06b
+            wb-utils: 4.21.2-wb100
 
     wb-2401:
         packages-common: &packages-wb-2401


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
доделки по wb8:
ядро - ppp в конфиг; exfat и ntfs в конфиг
wb-utils: фиксы wb-gsm для wb8