### PR TITLE
backport port probe feature to wb-2404)

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -261,7 +261,7 @@ releases:
             wb-mqtt-db: 2.8.13
             wb-mqtt-db-cli: 1.4.5
             wb-mqtt-gpio: 2.13.1
-            wb-mqtt-homeui: 2.82.1-wb103
+            wb-mqtt-homeui: 2.82.1-wb107
             wb-mqtt-iec104: 1.1.7
             wb-mqtt-knx: 1.12.8
             wb-mqtt-logs: 1.4.6

--- a/releases.yaml
+++ b/releases.yaml
@@ -88,7 +88,7 @@ releases:
             wb-ble-tesliot: 1.1.1
             wb-cc2652p-flasher: 1.0.0
             wb-cloud-agent: 1.3.3-wb103
-            wb-configs: 3.22.1-wb102
+            wb-configs: 3.22.1-wb103
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.7.2
             wb-device-manager: 1.7.0
@@ -117,7 +117,7 @@ releases:
             wb-mqtt-db: 2.8.13
             wb-mqtt-db-cli: 1.4.5
             wb-mqtt-gpio: 2.13.1
-            wb-mqtt-homeui: 2.82.1-wb106
+            wb-mqtt-homeui: 2.82.1-wb107
             wb-mqtt-iec104: 1.1.7
             wb-mqtt-knx: 1.12.8
             wb-mqtt-logs: 1.4.6


### PR DESCRIPTION
backport port probe feature to wb-2404

backport cpu usage limitation for download archives feature (wb6-wb8, effective only on wb7-8)

На wb8 синхронизировал homeui с версией для wb6-wb7.

<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
