### PR TITLE
wb-configs (wb8) fast-forward to actual wb2404 features

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -295,7 +295,7 @@ releases:
             u-boot-tools-wb: 2:2024.01+wb1.0.0
 
             wb-hwconf-manager: 1.60.0
-            wb-configs: 3.23.1
+            wb-configs: 3.23.1-wb103
             wb-utils: 4.21.2-wb100
 
     wb-2401:


### PR DESCRIPTION
Мимо протокола без PR бэкпортировал вот эти изменения из wb-2404 в wb-2404-wb8, досадую.

https://github.com/wirenboard/wb-configs/commit/b709d1bde1006e7e16e2b4eb2177fd5c08a2695c
https://github.com/wirenboard/wb-configs/commit/38b2de57e207a21ac1f2047a44d58c1b52fdd1ac
https://github.com/wirenboard/wb-configs/commit/e49fc80fe77b5d3116804aa87750075ff12b1069

<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
