### PR TITLE
wb-2404-wb8: Change node.js to 20, add zigbee2mqtt

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -284,6 +284,8 @@ releases:
             wb-update-manager: 1.3.2
             wb-update-notifier: 0.1.0
             wb-zigbee2mqtt: 1.3.5
+            zigbee2mqtt: 1.39.0-wb101
+            zigbee2mqtt-1.18.1: 1.18.1-wb101
 
             linux-headers-wb8: 6.8.0-wb12~exp~feature+wb8+6+8~127~g52a272203a80
             linux-image-wb8: 6.8.0-wb12~exp~feature+wb8+6+8~127~g52a272203a80
@@ -295,7 +297,7 @@ releases:
             u-boot-tools-wb: 2:2024.01+wb1.0.0
 
             wb-hwconf-manager: 1.60.0
-            wb-configs: 3.23.1-wb103
+            wb-configs: 3.23.1-wb104
             wb-utils: 4.21.2-wb100
 
     wb-2401:


### PR DESCRIPTION
Если я правильно понимаю -- это должно завезти в релиз для wb8 долгожданную 20-ю ноду и zigbee2mqtt (современной версии и версии 1.18.1).

<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
