### PR TITLE
wb2404: wb-demo-kit-configs: 1.7.6 -> 1.8.0

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -90,7 +90,7 @@ releases:
             wb-cloud-agent: 1.3.3-wb103
             wb-configs: 3.22.1-wb103
             wb-daemon-watchdogs: '1.1'
-            wb-demo-kit-configs: 1.7.6
+            wb-demo-kit-configs: 1.8.0
             wb-device-manager: 1.7.0
             wb-diag-collect: 1.8.11
             wb-dt-overlays: 1.6.1
@@ -243,7 +243,7 @@ releases:
             wb-cc2652p-flasher: 1.0.0
             wb-cloud-agent: 1.3.3-wb103
             wb-daemon-watchdogs: '1.1'
-            wb-demo-kit-configs: 1.7.4
+            wb-demo-kit-configs: 1.8.0
             wb-device-manager: 1.7.0
             wb-diag-collect: 1.8.11
             wb-dt-overlays: 1.7.0


### PR DESCRIPTION
https://github.com/wirenboard/wb-demo-kit-configs/pull/33

Стали использовать новый счётчик