### PR TITLE
wb-2404: wb-mqtt-snmp 1.2.8 → 1.3.0

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -128,7 +128,7 @@ releases:
             wb-mqtt-serial: 2.118.0-wb104
             wb-mqtt-smartbus: '1.2'
             wb-mqtt-smartweb: 1.4.4
-            wb-mqtt-snmp: 1.2.8
+            wb-mqtt-snmp: 1.3.0
             wb-mqtt-urri: 1.2.1
             wb-mqtt-w1: 2.2.10
             wb-mqtt-zabbix: '0.2'
@@ -272,7 +272,7 @@ releases:
             wb-mqtt-rfblinds: 1.0.2
             wb-mqtt-serial: 2.118.0-wb104
             wb-mqtt-smartweb: 1.4.4
-            wb-mqtt-snmp: 1.2.8
+            wb-mqtt-snmp: 1.3.0
             wb-mqtt-urri: 1.2.1
             wb-mqtt-w1: 2.2.10
             wb-nm-helper: 1.33.3


### PR DESCRIPTION
* https://github.com/wirenboard/wb-mqtt-snmp/pull/17
* https://github.com/wirenboard/wb-mqtt-snmp/pull/16