### PR TITLE
wb-2404: wb-ec-firmware v1.3.1 -> v1.3.2

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -94,7 +94,7 @@ releases:
             wb-device-manager: 1.7.0
             wb-diag-collect: 1.8.11
             wb-dt-overlays: 1.6.1
-            wb-ec-firmware: 1.3.1
+            wb-ec-firmware: 1.3.2
             wb-essential: 1.18.6
             wb-firmware-realtek: 1.0.3
             wb-homa-adc: 2.6.5
@@ -247,7 +247,7 @@ releases:
             wb-device-manager: 1.7.0
             wb-diag-collect: 1.8.11
             wb-dt-overlays: 1.7.0
-            wb-ec-firmware: 1.3.1
+            wb-ec-firmware: 1.3.2
             wb-essential: 1.18.6
             wb-firmware-realtek: 1.0.3
             wb-knxd-config: 1.1.3


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
на производстве плохо прошивался вбек; порисёчили - нарисёчили, что в wb-ec-firmware-update нужен слип
https://github.com/wirenboard/wb-embedded-controller/pull/36