### PR TITLE
wb-2404: update homeui 2.82.1-wb107 → 2.82.1-wb108

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -117,7 +117,7 @@ releases:
             wb-mqtt-db: 2.8.13
             wb-mqtt-db-cli: 1.4.5
             wb-mqtt-gpio: 2.13.1
-            wb-mqtt-homeui: 2.82.1-wb107
+            wb-mqtt-homeui: 2.82.1-wb108
             wb-mqtt-iec104: 1.1.7
             wb-mqtt-knx: 1.12.8
             wb-mqtt-logs: 1.4.6
@@ -262,7 +262,7 @@ releases:
             wb-mqtt-db: 2.8.13
             wb-mqtt-db-cli: 1.4.5
             wb-mqtt-gpio: 2.13.1
-            wb-mqtt-homeui: 2.82.1-wb107
+            wb-mqtt-homeui: 2.82.1-wb108
             wb-mqtt-iec104: 1.1.7
             wb-mqtt-knx: 1.12.8
             wb-mqtt-logs: 1.4.6


### PR DESCRIPTION
https://github.com/wirenboard/homeui/pull/596