### PR TITLE
wb-2404: check ports backport

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -88,7 +88,7 @@ releases:
             wb-ble-tesliot: 1.1.1
             wb-cc2652p-flasher: 1.0.0
             wb-cloud-agent: 1.3.3-wb103
-            wb-configs: 3.22.1-wb103
+            wb-configs: 3.22.1-wb104
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.8.0
             wb-device-manager: 1.7.0
@@ -117,7 +117,7 @@ releases:
             wb-mqtt-db: 2.8.13
             wb-mqtt-db-cli: 1.4.5
             wb-mqtt-gpio: 2.13.1
-            wb-mqtt-homeui: 2.82.1-wb108
+            wb-mqtt-homeui: 2.82.1-wb109
             wb-mqtt-iec104: 1.1.7
             wb-mqtt-knx: 1.12.8
             wb-mqtt-logs: 1.4.6
@@ -262,7 +262,7 @@ releases:
             wb-mqtt-db: 2.8.13
             wb-mqtt-db-cli: 1.4.5
             wb-mqtt-gpio: 2.13.1
-            wb-mqtt-homeui: 2.82.1-wb108
+            wb-mqtt-homeui: 2.82.1-wb109
             wb-mqtt-iec104: 1.1.7
             wb-mqtt-knx: 1.12.8
             wb-mqtt-logs: 1.4.6
@@ -297,7 +297,7 @@ releases:
             u-boot-tools-wb: 2:2024.01+wb1.0.0
 
             wb-hwconf-manager: 1.60.0
-            wb-configs: 3.23.1-wb104+1
+            wb-configs: 3.23.1-wb104+2
             wb-utils: 4.21.2-wb100
 
     wb-2401:


### PR DESCRIPTION
* wb-mqtt-homeui: 2.82.1-wb108 -> 2.82.1-wb109
* wb7: wb-configs: 3.22.1-wb103 -> 3.22.1-wb104
* wb8: wb-configs: 3.23.1-wb104+1 -> 3.23.1-wb104+2

https://github.com/wirenboard/homeui/pull/593
https://github.com/wirenboard/wb-configs/pull/171
https://github.com/wirenboard/wb-configs/pull/170
