### PR TITLE
Update WB-MRGB testing firmware to 3.4.4

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1432,8 +1432,8 @@ releases:
             map6semG16: 2.8.1
             # WB-MRGB
             mrgbw: 3.3.4        # на данном таргете на версиях старше 3.3.4 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
-            mrgbwG: 3.4.3
-            ledG: 3.4.3
+            mrgbwG: 3.4.4
+            ledG: 3.4.4
             # WB-MCM
             mcm8: 1.6.5
             mcm8G: 1.6.5


### PR DESCRIPTION
https://github.com/wirenboard/wb-mrgb/pull/82