### PR TITLE
wb-2407: fix wb-mqtt-nm-helper

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -135,7 +135,7 @@ releases:
             wb-mqtt-urri: 1.2.2
             wb-mqtt-w1: 2.2.11
             wb-mqtt-zabbix: '0.2'
-            wb-nm-helper: 1.33.7
+            wb-nm-helper: 1.33.8
             wb-rules: 2.20.15
             wb-rules-system: 1.11.1
             wb-suite: 1.19.0


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
поднимал версию у python3-wb-mqtt-nm-helper, а у самого хелпера - нет