### PR TITLE
wb-2407: modbus-utils-rpc 1.2.2 → 1.2.3

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -49,7 +49,7 @@ releases:
             mmc-utils: 0+git20180327.b4fe0c8c-1+wb1
             mobile-broadband-provider-info: 20230416-1
             modbus-utils: 1.2.10
-            modbus-utils-rpc: 1.2.2
+            modbus-utils-rpc: 1.2.3
             modemmanager: 1.20.0-1~bpo11+1-wb108
             modemmanager-dev: 1.20.0-1~bpo11+1-wb108
             modemmanager-doc: 1.20.0-1~bpo11+1-wb108


### PR DESCRIPTION
* https://github.com/wirenboard/modbus-utils-rpc/pull/18