### PR TITLE
wb-2407: wb-hwconf-manager v1.61.1 -> v1.61.2

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -105,7 +105,7 @@ releases:
             wb-homa-ism-radio: 1.17.3
             wb-homa-rfsniffer: 1.0.9
             wb-homa-w1: 2.2.11
-            wb-hwconf-manager: 1.61.1
+            wb-hwconf-manager: 1.61.2
             wb-knxd-config: 1.1.4
             wb-mb-explorer: 1.2.8
             wb-mcu-fw-flasher: 1.4.0


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
починили wbio-прерывания на wb8; нада в 2407
https://github.com/wirenboard/wb-hwconf-manager/pull/126