### PR TITLE
wb-2407: linux-image-wb8 v6.8.0-wb101 -> v6.8.0-wb103

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -174,10 +174,10 @@ releases:
         wb8/bullseye:
             <<: *packages-wb-2407
 
-            linux-headers-wb8: 6.8.0-wb101
-            linux-image-wb8: 6.8.0-wb101
-            linux-libc-dev: 6.8.0-wb101
-            wb-bootlet-wb8x: 6.8.0-wb101-fs1.3.2-deb11-202407251008
+            linux-headers-wb8: 6.8.0-wb103
+            linux-image-wb8: 6.8.0-wb103
+            linux-libc-dev: 6.8.0-wb103
+            wb-bootlet-wb8x: 6.8.0-wb103-fs1.3.2-deb11-202407251008
 
             u-boot-tools-wb: 2:2024.01+wb1.0.0
             u-boot-wb8: 2:2024.01+wb1.0.0


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
в wb8 заехал wireguard; договорились с @webconn сделать fastforward