### PR TITLE
wb-2407: wb-mcu-fw-updater 1.11.0 → 1.11.2

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -73,7 +73,7 @@ releases:
             python3-paho-socket: 0.0.3-2
             python3-umodbus: 1.0.4-1+wb1
             python3-wb-common: 2.2.0
-            python3-wb-mcu-fw-updater: 1.11.0
+            python3-wb-mcu-fw-updater: 1.11.2
             python3-wb-mqtt-metrics: 0.3.3
             python3-wb-nm-helper: 1.33.8
             python3-wb-test-suite-deps: 1.19.0
@@ -109,7 +109,7 @@ releases:
             wb-knxd-config: 1.1.4
             wb-mb-explorer: 1.2.8
             wb-mcu-fw-flasher: 1.4.0
-            wb-mcu-fw-updater: 1.11.0
+            wb-mcu-fw-updater: 1.11.2
             wb-modbus-ext-scanner: 1.2.5
             wb-mqtt-adc: 2.6.5
             wb-mqtt-apcsnmp: '0.2'


### PR DESCRIPTION
* https://github.com/wirenboard/wb-mcu-fw-updater/pull/77
* https://github.com/wirenboard/wb-mcu-fw-updater/pull/78