### PR TITLE
wb-2407: add nodejs-16

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -60,6 +60,7 @@ releases:
             network-manager-config-connectivity-debian: 1.42.4-1~bpo11+1-wb102
             network-manager-dev: 1.42.4-1~bpo11+1-wb102
             nodejs: 16.18.1-deb-1nodesource1
+            nodejs-16: 16.20.2-deb-1nodesource1
             python-gsmmodem-new: '1:0.11'
             python-gspread: 1:0.4.1
             python-mosquitto: 1.3.4-2contactless1


### PR DESCRIPTION
1. Rename package to node-16:
```sh
$ wget https://deb.nodesource.com/node_16.x/pool/main/n/nodejs/nodejs_16.20.2-deb-1nodesource1_armhf.deb
$ dpkg-deb -R nodejs_16.20.2-deb-1nodesource1_armhf.deb debdir
$ # rename Package to node-16 in debdir/debian/control
$ # append nodejs to Conflicts, Provides in debdir/debian/control
$ dpkg-deb -b debdir nodejs-16_16.20.2-deb-1nodesource1_armhf.deb
```
2. Upload deb (https://github.com/wirenboard/wb-releases/pull/747) and check:
```sh
$ apt policy nodejs-16
nodejs-16:
  Installed: (none)
  Candidate: 16.20.2-deb-1nodesource1
  Version table:
     16.20.2-deb-1nodesource1 990
        990 http://deb.wirenboard.com/wb7/bullseye testing/main armhf Packages
```

Note: nodejs will be upgraded to 20.x after z2m rebuild with proper deps.