### PR TITLE
wb-2407: wb-mcu-fw-updater v1.11.2 -> v1.11.3

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -74,7 +74,7 @@ releases:
             python3-paho-socket: 0.0.3-2
             python3-umodbus: 1.0.4-1+wb1
             python3-wb-common: 2.2.0
-            python3-wb-mcu-fw-updater: 1.11.2
+            python3-wb-mcu-fw-updater: 1.11.3
             python3-wb-mqtt-metrics: 0.3.3
             python3-wb-nm-helper: 1.33.8
             python3-wb-test-suite-deps: 1.19.0
@@ -110,7 +110,7 @@ releases:
             wb-knxd-config: 1.1.4
             wb-mb-explorer: 1.2.8
             wb-mcu-fw-flasher: 1.4.0
-            wb-mcu-fw-updater: 1.11.2
+            wb-mcu-fw-updater: 1.11.3
             wb-modbus-ext-scanner: 1.2.5
             wb-mqtt-adc: 2.6.5
             wb-mqtt-apcsnmp: '0.2'


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-mcu-fw-updater/pull/76
обсуждали - всё-таки, решили влить
надо бекпорт; штука полезная