### PR TITLE
mrgbwG and ledG update to 3.5.0 in testing

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1167,8 +1167,8 @@ releases:
             map6semG16: 2.10.0
             # WB-MRGB
             mrgbw: 3.3.4        # на данном таргете на версиях старше 3.3.4 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
-            mrgbwG: 3.4.4
-            ledG: 3.4.4
+            mrgbwG: 3.5.0
+            ledG: 3.5.0
             # WB-MCM
             mcm8: 1.6.5
             mcm8G: 1.6.5


### PR DESCRIPTION
https://github.com/wirenboard/wb-mrgb/pull/84
