### PR TITLE
wb-2407: update rapidscada to 6.3.0-1

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -80,7 +80,7 @@ releases:
             python3-wb-test-suite-deps: 1.19.0
             python3-wb-update-manager: 1.3.5
             python3-zpl: 0.1.10-wb101
-            rapidscada: 6.2.1-1
+            rapidscada: 6.3.0-1
             serial-tool: 1.2.1
             sigrok-cli: 0.7.2-1
             ss-dev: 2.0-1.46.2-2+wb1


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
добавили пакет ручками какое-то время назад