### PR TITLE
Update WB-MAO4(20) testing firmware to 2.6.1

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1067,7 +1067,7 @@ releases:
             # WB-MAO
             mao4: 2.4.4         # на данном таргете на версиях старше 2.4.4 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
             mao4G: 2.5.1
-            mao4G-C: 2.6.0
+            mao4G-C: 2.6.1
             # WB-MAI
             wb-mai-v10: 1.3.1
             wb-mai6: 2.1.0

--- a/releases.yaml
+++ b/releases.yaml
@@ -1174,8 +1174,8 @@ releases:
             mcm8G: 1.6.5
             # WB-MAO
             mao4: 2.4.4         # на данном таргете на версиях старше 2.4.4 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
-            mao4G: 2.5.1
-            mao4G-C: 2.6.0
+            mao4G: 2.6.1
+            mao4G-C: 2.6.1
             # WB-MAI
             wb-mai-v10: 1.3.1
             wb-mai6: 2.1.0

--- a/releases.yaml
+++ b/releases.yaml
@@ -129,7 +129,7 @@ releases:
             wb-mqtt-metrics: 0.3.3
             wb-mqtt-opcua: 1.1.7
             wb-mqtt-rfblinds: 1.0.3
-            wb-mqtt-serial: 2.138.1-wb104
+            wb-mqtt-serial: 2.138.1-wb105
             wb-mqtt-smartbus: '1.2'
             wb-mqtt-smartweb: 1.4.6
             wb-mqtt-snmp: 1.3.3


### PR DESCRIPTION
[<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
](https://github.com/wirenboard/wb-mao4/pull/27)