### PR TITLE
WB-MDM3: update stable to 2.9.0; WB-2407: update wb-mqtt-serial to 2.138.1-wb106

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -129,7 +129,7 @@ releases:
             wb-mqtt-metrics: 0.3.3
             wb-mqtt-opcua: 1.1.7
             wb-mqtt-rfblinds: 1.0.3
-            wb-mqtt-serial: 2.138.1-wb105
+            wb-mqtt-serial: 2.138.1-wb106
             wb-mqtt-smartbus: '1.2'
             wb-mqtt-smartweb: 1.4.6
             wb-mqtt-snmp: 1.3.3
@@ -1037,7 +1037,7 @@ releases:
             mdm3: 2.6.6         # на данном таргете на версиях старше 2.6.6 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
             mdm3_042: 2.6.6     # на данном таргете на версиях старше 2.6.6 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
             mdm3_26: 2.6.6      # на данном таргете на версиях старше 2.6.6 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
-            mdm3G26: 2.7.1
+            mdm3G26: 2.9.0
             # WB-MAP
             map3e: 2.7.5
             map3e16: 2.8.1


### PR DESCRIPTION
wb-mqtt-serial: https://github.com/wirenboard/wb-mqtt-serial/pull/819
WB-MDM3: https://github.com/wirenboard/wb-md/pull/53