### PR TITLE
wb-2407 wb7,wb8: update u-boot & u-boot-tools-wb (fit_info opens fit …

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -88,7 +88,7 @@ releases:
             task-wb-base-system: 1.19.0
             task-wb-common-pkgs: 1.19.0
             telegraf-wb-cloud-agent: 1.29.1-wb2
-            u-boot-tools-wb: 2:2021.10+wb1.7.2
+            u-boot-tools-wb: 2:2021.10+wb1.7.3
             wb-ble-tesliot: 1.1.1
             wb-cc2652p-flasher: 1.0.0
             wb-cloud-agent: 1.5.7
@@ -168,7 +168,7 @@ releases:
 
             linux-image-wb7: 5.10.35-wb169
             linux-headers-wb7: 5.10.35-wb169
-            u-boot-wb7: 2:2021.10+wb1.7.2
+            u-boot-wb7: 2:2021.10+wb1.7.3
             wb-bootlet-wb7x: 5.10.35-wb169-fs1.3.2-deb11-202407251009
             mplc4-wirenboard7: 1.3.5.18656
 
@@ -180,8 +180,8 @@ releases:
             linux-libc-dev: 6.8.0-wb104
             wb-bootlet-wb8x: 6.8.0-wb104-fs1.3.2-deb11-202407251008
 
-            u-boot-tools-wb: 2:2024.01+wb1.0.0
-            u-boot-wb8: 2:2024.01+wb1.0.0
+            u-boot-tools-wb: 2:2024.01+wb1.0.1
+            u-boot-wb8: 2:2024.01+wb1.0.1
 
             task-wirenboard-wb8: 1.19.0
             arm-trusted-firmware: 2.10.0+dfsg-1+wb2


### PR DESCRIPTION
…as r/o)
https://github.com/wirenboard/u-boot-private/pull/49
https://github.com/wirenboard/u-boot-private/pull/48
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
чтобы wb-initramfs имела правильный fit_info - нужно протащить в stable (пот wb-initramfs собирается из стабильных фитов)