### PR TITLE
Update mrgbwG and ledG testing firmware to 3.5.1

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1177,8 +1177,8 @@ releases:
             map6semG16: 2.10.1
             # WB-MRGB
             mrgbw: 3.3.4        # на данном таргете на версиях старше 3.3.4 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
-            mrgbwG: 3.5.0
-            ledG: 3.5.0
+            mrgbwG: 3.5.1
+            ledG: 3.5.1
             # WB-MCM
             mcm8: 1.6.6
             mcm8G: 1.6.6


### PR DESCRIPTION
https://github.com/wirenboard/wb-mrgb/pull/85