### PR TITLE
wb-2407, wb-2410: u-boot v2:2024.01+wb1.0.1 -> v2:2024.01+wb1.0.2

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -179,8 +179,8 @@ releases:
             linux-libc-dev: 6.8.0-wb114+wb100
             wb-bootlet-wb8x: 6.8.0-wb114+wb100-fs1.3.4-deb11-202411041234
 
-            u-boot-tools-wb: 2:2024.01+wb1.0.1
-            u-boot-wb8: 2:2024.01+wb1.0.1
+            u-boot-tools-wb: 2:2024.01+wb1.0.2
+            u-boot-wb8: 2:2024.01+wb1.0.2
 
             task-wirenboard-wb8: 1.19.0
             arm-trusted-firmware: 2.10.0+dfsg-1+wb2
@@ -367,8 +367,8 @@ releases:
             linux-libc-dev: 6.8.0-wb104
             wb-bootlet-wb8x: 6.8.0-wb104-fs1.3.2-deb11-202407251008
 
-            u-boot-tools-wb: 2:2024.01+wb1.0.1
-            u-boot-wb8: 2:2024.01+wb1.0.1
+            u-boot-tools-wb: 2:2024.01+wb1.0.2
+            u-boot-wb8: 2:2024.01+wb1.0.2
 
             task-wirenboard-wb8: 1.19.0
             arm-trusted-firmware: 2.10.0+dfsg-1+wb2


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/u-boot-private/pull/52/
Женя починил убут; дальше - мы заносим в релизы и фиты