### PR TITLE
wb-2410: wb8: kernel v6.8.0-wb114+wb101 -> v6.8.0-wb114+wb102

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -174,9 +174,9 @@ releases:
         wb8/bullseye:
             <<: *packages-wb-2410
 
-            linux-headers-wb8: 6.8.0-wb114+wb101
-            linux-image-wb8: 6.8.0-wb114+wb101
-            linux-libc-dev: 6.8.0-wb114+wb101
+            linux-headers-wb8: 6.8.0-wb114+wb102
+            linux-image-wb8: 6.8.0-wb114+wb102
+            linux-libc-dev: 6.8.0-wb114+wb102
             wb-bootlet-wb8x: 6.8.0-wb117-fs1.3.6-deb11-202411060755
 
             u-boot-tools-wb: 2:2024.01+wb1.0.3


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
производству нада занести вот [ето](https://github.com/wirenboard/linux/pull/277) в 2410