### PR TITLE
wb-2410: wb-utils v4.25.0 -> v4.25.1

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -140,7 +140,7 @@ releases:
             wb-test-suite-dummy: 1.19.0
             wb-update-manager: 1.3.5
             wb-update-notifier: 0.1.0
-            wb-utils: 4.25.0
+            wb-utils: 4.25.1
             wb-welrok: 0.0.9
             wb-zigbee2mqtt: 1.3.5
             webif: '1.5'


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
нашли-починили [весьма неприятную багу](https://github.com/wirenboard/wb-utils/pull/165); надо занести в релис