### PR TITLE
wb-2410: wb-ec-firmware: 2.0.1

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -93,7 +93,7 @@ releases:
             wb-device-manager: 1.14.1
             wb-diag-collect: 1.8.17
             wb-dt-overlays: 1.7.0
-            wb-ec-firmware: 2.0.0
+            wb-ec-firmware: 2.0.1
             wb-essential: 1.19.0
             wb-firmware-realtek: 1.0.3
             wb-homa-adc: 2.6.7


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-embedded-controller/pull/61