### PR TITLE
wb-2410: wb7: wb-ec-firmware: 1.3.2

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -93,7 +93,6 @@ releases:
             wb-device-manager: 1.14.1
             wb-diag-collect: 1.8.17
             wb-dt-overlays: 1.7.0
-            wb-ec-firmware: 2.0.1
             wb-essential: 1.19.0
             wb-firmware-realtek: 1.0.3
             wb-homa-adc: 2.6.7
@@ -171,6 +170,8 @@ releases:
             u-boot-tools-wb: 2:2021.10+wb1.7.3
             mplc4-wirenboard7: 1.3.5.18656
 
+            wb-ec-firmware: 1.3.2
+
         wb8/bullseye:
             <<: *packages-wb-2410
 
@@ -185,6 +186,8 @@ releases:
             task-wirenboard-wb8: 1.19.0
             arm-trusted-firmware: 2.10.0+dfsg-1+wb2
             e2fsprogs-udeb: 1.46.2-2+wb1
+
+            wb-ec-firmware: 2.0.1
 
     wb-2407:
         packages-common: &packages-wb-2407


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
Откатываем прошивку wbec для WB7 до состояния wb-2407. Непонятные проблемы со спящим режимом