### PR TITLE
Feature/wb6 wbec missed

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -159,6 +159,8 @@ releases:
             u-boot-tools-wb: 2:2021.10+wb1.7.3
             wb-bootlet-wb6x: 5.10.35-wb172-fs1.3.4-deb11-202410221540
 
+            wb-ec-firmware: 1.3.2
+
         wb7/bullseye:
             <<: *packages-wb-2410
 


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
для wb6 тоже нужен wbec, там ломаются зависимости