### PR TITLE
wb-2410: wb8: wb-ec-firmware: 2.0.2

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -189,7 +189,7 @@ releases:
             arm-trusted-firmware: 2.10.0+dfsg-1+wb2
             e2fsprogs-udeb: 1.46.2-2+wb1
 
-            wb-ec-firmware: 2.0.1
+            wb-ec-firmware: 2.0.2
 
     wb-2407:
         packages-common: &packages-wb-2407


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-embedded-controller/pull/62
обновляю пока только для wb8, если всё ок, то позже можно и для wb7 обновить