### PR TITLE
Add vendor packages

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -205,8 +205,10 @@ releases:
             wb-ec-firmware: 1.3.2
 
             mplc4-oni-plc-w: 1.3.6.21566
-            wb-mqtt-homeui: 2.103.3-wb102-cb8ea449
+            wb-mqtt-homeui: 2.103.3-wb103-cb8ea449-1
             wb-utils: 4.25.1-cb8ea449
+            wb-suite: 1.19.0-cb8ea449
+            wb-mqtt-serial: 2.146.0-wb101-cb8ea449
 
     wb-2407:
         packages-common: &packages-wb-2407

--- a/releases.yaml
+++ b/releases.yaml
@@ -191,6 +191,23 @@ releases:
 
             wb-ec-firmware: 2.0.1
 
+    wb-2410-cb8ea449:
+        wb7/bullseye:
+            <<: *packages-wb-2410
+
+            linux-headers-wb7: 5.10.35-wb172
+            linux-image-wb7: 5.10.35-wb172
+            u-boot-wb7: 2:2021.10+wb1.7.3
+            linux-libc-dev: 5.10.35-wb172
+            wb-bootlet-wb7x: 5.10.35-wb172-fs1.3.4-deb11-202410221544
+            u-boot-tools-wb: 2:2021.10+wb1.7.3
+
+            wb-ec-firmware: 1.3.2
+
+            mplc4-oni-plc-w: 1.3.6.21566
+            wb-mqtt-homeui: 2.103.3-wb102-cb8ea449
+            wb-utils: 4.25.1-cb8ea449
+
     wb-2407:
         packages-common: &packages-wb-2407
             atecc-util: 0.4.11


### PR DESCRIPTION
Продублировала пакеты ядра потому что в wb7/bullseye есть пакет mplc4-wirenboard7, а тут его не должно быть
mplc4-oni-plc-w закинула через upload deb
wb-mqtt-homeui https://github.com/wirenboard/homeui/pull/670
wb-utils https://github.com/wirenboard/wb-utils/pull/166
wb-suite https://github.com/wirenboard/wb-metapackages/pull/37
wb-mqtt-serial https://github.com/wirenboard/wb-mqtt-serial/pull/838