### PR TITLE
wb-2410: wb8-bootlet v6.8.0-wb117 -> 6.8.0-wb120

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -180,7 +180,7 @@ releases:
             linux-headers-wb8: 6.8.0-wb114+wb102
             linux-image-wb8: 6.8.0-wb114+wb102
             linux-libc-dev: 6.8.0-wb114+wb102
-            wb-bootlet-wb8x: 6.8.0-wb117-fs1.3.6-deb11-202411060755
+            wb-bootlet-wb8x: 6.8.0-wb120-fs1.3.6-deb11-202411060755
 
             u-boot-tools-wb: 2:2024.01+wb1.0.3
             u-boot-wb8: 2:2024.01+wb1.0.3


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
надо бы занести [вот ето](https://github.com/wirenboard/wb-initramfs/pull/16) в stable

только бутлет, поэтому и релизных веток никаких нет