### PR TITLE
wb-2410-cb8ea449: wb-utils v4.25.1-cb8ea449 -> v4.25.1-cb8ea449-1

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -206,7 +206,7 @@ releases:
 
             mplc4-oni-plc-w: 1.3.6.21566
             wb-mqtt-homeui: 2.103.3-wb103-cb8ea449-1
-            wb-utils: 4.25.1-cb8ea449
+            wb-utils: 4.25.1-cb8ea449-1
             wb-suite: 1.19.0-cb8ea449
             wb-mqtt-serial: 2.146.0-wb101-cb8ea449-1
 


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
надо занести быстрый [костылёк](https://github.com/wirenboard/wb-utils/pull/168)