### PR TITLE
WB-MAI6: Update stable firmware to 2.1.2

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1106,8 +1106,8 @@ releases:
             mao4G-C: 2.6.2
             # WB-MAI
             wb-mai-v10: 1.3.1
-            wb-mai6: 2.1.1
-            wb-mai6-15: 2.1.1
+            wb-mai6: 2.1.2
+            wb-mai6-15: 2.1.2
             # WB-MIO
             mio: 1.6.4
             # WB-REF


### PR DESCRIPTION
https://github.com/wirenboard/wb-mai6/pull/19