### PR TITLE
WB-MAI6: update testing firmware to 2.1.3

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1416,8 +1416,8 @@ releases:
             mao4G-C: 2.6.2
             # WB-MAI
             wb-mai-v10: 1.3.1
-            wb-mai6: 2.1.2
-            wb-mai6-15: 2.1.2
+            wb-mai6: 2.1.3
+            wb-mai6-15: 2.1.3
             # WB-MIO
             mio: 1.6.5
             # WB-REF


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-mai6/pull/16