### PR TITLE
Fix all metapackages versions

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -80,7 +80,7 @@ releases:
             python3-wb-mcu-fw-updater: 1.11.6
             python3-wb-mqtt-metrics: 0.3.6
             python3-wb-nm-helper: 1.34.9
-            python3-wb-test-suite-deps: 1.19.1
+            python3-wb-test-suite-deps: 1.19.0
             python3-wb-update-manager: 1.3.5
             python3-zpl: 0.1.10-wb101
             rapidscada: 6.3.0-1
@@ -88,8 +88,8 @@ releases:
             sigrok-cli: 0.7.2-1
             ss-dev: 2.0-1.46.2-2+wb1
             tailscale: 1.78.1
-            task-wb-base-system: 1.19.1
-            task-wb-common-pkgs: 1.19.1  
+            task-wb-base-system: 1.19.0
+            task-wb-common-pkgs: 1.19.0  
             telegraf-wb-cloud-agent: 1.29.1-wb2  
             wb-ble-tesliot: 1.1.1  
             wb-cc2652p-flasher: 1.0.0
@@ -101,7 +101,7 @@ releases:
             wb-diag-collect: 1.8.18
             wb-dt-overlays: 1.7.0
             wb-ec-firmware: 2.0.2
-            wb-essential: 1.19.1
+            wb-essential: 1.19.0
             wb-firmware-realtek: 1.0.3
             wb-homa-adc: 2.6.7
             wb-homa-gpio: 2.15.2
@@ -144,7 +144,7 @@ releases:
             wb-suite: 1.19.0
             wb-test-suite: '1.20'
             wb-test-suite-deps: 1.12.0
-            wb-test-suite-dummy: 1.19.1
+            wb-test-suite-dummy: 1.19.0
             wb-update-manager: 1.3.5
             wb-update-notifier: 0.1.0
             wb-utils: 4.25.2
@@ -194,7 +194,7 @@ releases:
 
             arm-trusted-firmware: 2.10.0+dfsg-1+wb2
             e2fsprogs-udeb: 1.46.2-2+wb1
-            task-wirenboard-wb8: 1.19.1  
+            task-wirenboard-wb8: 1.19.0  
           
             tm-cpps: '16402'
             


### PR DESCRIPTION
Интеграции попросили не включать сценарии, поэтому в релизе поставила версию для wb-suite 1.19.0 вместо текущей 1.19.1. 
Надо помимо wb-suite понижать версии у остальных пакетов из метапэкиджа тоже, потому что тогда релизную ветку не поставить