### PR TITLE
WB-LED: update testing firmware to 3.5.2

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1405,8 +1405,8 @@ releases:
             map6semG16: 2.10.2
             # WB-MRGB
             mrgbw: 3.3.4        # на данном таргете на версиях старше 3.3.4 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
-            mrgbwG: 3.5.1
-            ledG: 3.5.1
+            mrgbwG: 3.5.2
+            ledG: 3.5.2
             # WB-MCM
             mcm8: 1.6.6
             mcm8G: 1.6.6


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-mrgb/pull/86