### PR TITLE
wb-2501: wb-device-manager: 1.16.1 -> 1.16.2

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -97,7 +97,7 @@ releases:
             wb-configs: 3.35.0
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.9.0
-            wb-device-manager: 1.16.1
+            wb-device-manager: 1.16.2
             wb-diag-collect: 1.8.18
             wb-dt-overlays: 1.7.0
             wb-ec-firmware: 2.0.2


### PR DESCRIPTION
https://github.com/wirenboard/wb-device-manager/pull/57
