### PR TITLE
Update WB-LED stable firmware to 2.5.2

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -131,7 +131,7 @@ releases:
             wb-mqtt-metrics: 0.3.7
             wb-mqtt-opcua: 1.1.11
             wb-mqtt-rfblinds: 1.0.3
-            wb-mqtt-serial: 2.153.3
+            wb-mqtt-serial: 2.153.3-wb100
             wb-mqtt-smartbus: '1.2'
             wb-mqtt-smartweb: 1.4.9
             wb-mqtt-snmp: 1.3.8
@@ -1303,8 +1303,8 @@ releases:
             map6semG16: 2.10.2
             # WB-MRGB
             mrgbw: 3.3.4        # на данном таргете на версиях старше 3.3.4 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
-            mrgbwG: 3.5.1
-            ledG: 3.5.1
+            mrgbwG: 3.5.2
+            ledG: 3.5.2
             # WB-MCM
             mcm8: 1.6.6
             mcm8G: 1.6.6


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-releases/pull/841
https://github.com/wirenboard/wb-mqtt-serial/pull/868