### PR TITLE
wb-2501: wb-ec-firmware: 2.0.3

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -100,7 +100,7 @@ releases:
             wb-device-manager: 1.16.2
             wb-diag-collect: 1.9.0-wb100
             wb-dt-overlays: 1.7.0
-            wb-ec-firmware: 2.0.2
+            wb-ec-firmware: 2.0.3
             wb-essential: 1.19.0
             wb-firmware-realtek: 1.0.3
             wb-homa-adc: 2.6.7


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-embedded-controller/pull/63