### PR TITLE
Update WB-LED and WB-MRGBW-D testing firmware to 3.5.3

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1446,8 +1446,8 @@ releases:
             map12eGe: 2.10.4
             # WB-MRGB
             mrgbw: 3.3.4        # на данном таргете на версиях старше 3.3.4 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
-            mrgbwG: 3.5.2
-            ledG: 3.5.2
+            mrgbwG: 3.5.3
+            ledG: 3.5.3
             # WB-MCM
             mcm8: 1.6.6
             mcm8G: 1.6.6


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-mrgb/pull/87