### PR TITLE
wb-2501: wb-ec-firmware: 2.0.4; wb-mcu-fw-flasher: 1.4.1

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -100,7 +100,7 @@ releases:
             wb-device-manager: 1.16.2
             wb-diag-collect: 1.9.0-wb100
             wb-dt-overlays: 1.7.0
-            wb-ec-firmware: 2.0.3
+            wb-ec-firmware: 2.0.4
             wb-essential: 1.19.0
             wb-firmware-realtek: 1.0.3
             wb-homa-adc: 2.6.7
@@ -111,7 +111,7 @@ releases:
             wb-hwconf-manager: 1.66.0
             wb-knxd-config: 1.1.5
             wb-mb-explorer: 1.2.8
-            wb-mcu-fw-flasher: 1.4.0
+            wb-mcu-fw-flasher: 1.4.1
             wb-mcu-fw-updater: 1.11.6
             wb-modbus-ext-scanner: 1.2.5
             wb-mqtt-adc: 2.6.7


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-embedded-controller/pull/64
https://github.com/wirenboard/wb-mcu-fw-flasher/pull/28