### PR TITLE
wb-2410-cb8ea449: add magnetometer-required packages

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -407,7 +407,9 @@ releases:
             wb-utils: 4.25.1-cb8ea449-1
             wb-suite: 1.19.0-cb8ea449
             wb-mqtt-serial: 2.146.0-wb101-cb8ea449-2
-            custom-settings-cb8ea449: 1.0.0
+            custom-settings-cb8ea449: 1.1.0
+            wb-hwconf-manager: 1.67.0
+            wb-mqtt-tlv493: 1.0.0
 
     wb-2407:
         packages-common: &packages-wb-2407


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
все пакетики, нужные для работы магнетометра у cb8ea449:
[сеттингз](https://github.com/wirenboard/custom-settings-cb8ea449/pull/2)
[хвконф](https://github.com/wirenboard/wb-hwconf-manager/pull/140) от релиза отличается только линтером => считаю, не надо ничего бекпортировать
[новый сервис](https://github.com/wirenboard/wb-mqtt-tlv43d/pull/1)

можно смотреть; пока не соберется - не волью