### PR TITLE
Update testing firmware for WB-LED to 3.5.4

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1448,8 +1448,8 @@ releases:
             map12eGe: 2.10.4
             # WB-MRGB
             mrgbw: 3.3.4        # на данном таргете на версиях старше 3.3.4 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
-            mrgbwG: 3.5.3
-            ledG: 3.5.3
+            mrgbwG: 3.5.4
+            ledG: 3.5.4
             # WB-MCM
             mcm8: 1.6.6
             mcm8G: 1.6.6


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-mrgb/pull/88