### PR TITLE
Exclude python3-json-rpc

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1657,7 +1657,7 @@ staging:
         - "libwbmqtt1-3*"
         - "libwbmqtt1-4*"
         - "mqtt-logger"
-        - "python-json-rpc"
+        - "python*-json-rpc"
         - "python-mqttrpc"
         - "python-wb-common"
         - "python-wb-mcu-fw-updater"


### PR DESCRIPTION
* https://github.com/wirenboard/python-mqtt-rpc/pull/16

Чтобы в следующий релиз уже не был включен, в текущем релизе остается.