### PR TITLE
wb-2501: wb8 kernel v6.8.0-wb124+wb100 -> 6.8.0-wb124+wb101

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -184,9 +184,9 @@ releases:
         wb8/bullseye:
             <<: *packages-wb-2501
 
-            linux-libc-dev: 6.8.0-wb124+wb100
-            linux-image-wb8: 6.8.0-wb124+wb100
-            linux-headers-wb8: 6.8.0-wb124+wb100
+            linux-libc-dev: 6.8.0-wb124+wb101
+            linux-image-wb8: 6.8.0-wb124+wb101
+            linux-headers-wb8: 6.8.0-wb124+wb101
             u-boot-wb8: 2:2024.01+wb1.0.3
             u-boot-tools-wb: 2:2024.01+wb1.0.3
             wb-bootlet-wb8x: 6.8.0-wb124-fs1.3.7-deb11-202412021728


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->

бекпорт [починки старта phy](https://github.com/wirenboard/linux/pull/314) на wb8

не соберется, пот https://github.com/wirenboard/linux/pull/315 еще не влито => я сам проконтролирую