### PR TITLE
wb-2501: python3-wb-common v2.2.4 -> v2.2.6

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -76,7 +76,7 @@ releases:
             python3-mqttrpc: 1.2.5
             python3-paho-socket: 0.0.3-2
             python3-umodbus: 1.0.4-1+wb1
-            python3-wb-common: 2.2.4
+            python3-wb-common: 2.2.6
             python3-wb-mcu-fw-updater: 1.11.6
             python3-wb-mqtt-metrics: 0.3.7
             python3-wb-nm-helper: 1.35.0


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
заносим в wb-2501 [фикс wb-gen-serial для wb6](https://github.com/wirenboard/wb-common/pull/19)

не соберется, пот PR еще не влит - это я сам проконтролирую