### PR TITLE
Update WB-MRWM2 stable firmware to 1.21.2

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1237,7 +1237,7 @@ releases:
             mrwl3Ge: 1.21.5
             mr6cpGe: 1.21.5
             # WB-MRWM2
-            mrwm2G: 1.21.1
+            mrwm2G: 1.21.2
             # WB-MWAC
             wbmwac: 1.19.2      # на данном таргете на версиях старше 1.19.2 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
             wbmwac_042: 1.19.2  # на данном таргете на версиях старше 1.19.2 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)


### PR DESCRIPTION
37 дней в тестинге

https://github.com/wirenboard/wb-mrwm/pull/12