### PR TITLE
WB-MCM: add new signature mcm8Ge and update testing firmwares to 1.6.8

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1521,6 +1521,7 @@ releases:
             # WB-MCM
             mcm8: 1.6.6
             mcm8G: 1.6.6
+            mcm8Ge: 1.6.8
             # WB-MAO
             mao4: 2.4.4         # на данном таргете на версиях старше 2.4.4 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
             mao4G: 2.6.3
@@ -1659,8 +1660,9 @@ releases:
             mrgbwG: 3.5.5
             ledG: 3.5.5
             # WB-MCM
-            mcm8: 1.6.7
-            mcm8G: 1.6.7
+            mcm8: 1.6.8
+            mcm8G: 1.6.8
+            mcm8Ge: 1.6.8
             # WB-MAO
             mao4: 2.4.4         # на данном таргете на версиях старше 2.4.4 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
             mao4G: 2.6.3


### PR DESCRIPTION
Добавлена в stable новая сигнатура для WB-MCM без EEPROM: mcm8Ge
Обновлены версии тестовых прошивок WB-MCM на 1.6.8
https://github.com/wirenboard/wb-mcm/pull/43