### PR TITLE
Fix fw updates in releases

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1735,8 +1735,14 @@ suites:
         unstable: _firmwares_testing
 
         wb-2207: _firmwares_stable
-        wb-2501-cb8ea449: _firmwares_stable
+        wb-2304-70549e24: _firmwares_stable
+        wb-2307-cb8ea449: _firmwares_stable
+        wb-2307-a70ab64c: _firmwares_stable
+        wb-2407-e1d931dd: _firmwares_stable
+        wb-2407-a70ab64c: _firmwares_stable
         wb-2410-cb8ea449: _firmwares_stable
+        wb-2501-cb8ea449: _firmwares_stable
+
 
 
 targets:

--- a/releases.yaml
+++ b/releases.yaml
@@ -1735,6 +1735,9 @@ suites:
         unstable: _firmwares_testing
 
         wb-2207: _firmwares_stable
+        wb-2501-cb8ea449: _firmwares_stable
+        wb-2410-cb8ea449: _firmwares_stable
+
 
 targets:
     wb8/trixie:


### PR DESCRIPTION
В чате с вендором появился запрос на обновление прошивки mai6 клиента, какая то проблема с трехпроводным подключением.
Попытались обновить и updater не смог найти подходящий релиз для прошивок, тк он кастомный. Добавили релиз для прошивочек

Ошибка случилась на кастомном релизе 2410, но 2501 тоже я думаю надо добавить