### PR TITLE
Update FW versions for ONOKOM gateways

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1540,11 +1540,13 @@ releases:
             # ONOKOM
             ok_tcl1b: 0.3.6
             ok_tcl3b: 0.4.6
+            ok_tcl3c: 0.5.0
             ok_aux1b: 0.4.7
             ok_dk1b: 0.4.7
             ok_dk5b: 0.4.7
             ok_gr1b: 0.3.8
             ok_gr3b: 0.4.1
+            ok_gr3c: 0.5.0
             ok_hr1b: 0.3.8
             ok_hs3b: 0.4.6
             ok_hs5b: 0.4.3
@@ -1554,6 +1556,8 @@ releases:
             ok_mdvrfb: 0.4.3
             ok_me1b: 0.4.7
             ok_tn1b: 0.4.7
+            ok_ht1b: 0.5.0
+            ok_mh2b: 0.5.0
 
     _firmwares_testing:
         firmwares:
@@ -1681,22 +1685,26 @@ releases:
             refu: 1.4.6
             refuGe: 1.4.6
             # ONOKOM
-            ok_tcl1b: 0.3.6
+            ok_tcl1b: 0.5.0
             ok_tcl3b: 0.4.6
-            ok_aux1b: 0.4.7
+            ok_tcl3c: 0.5.0
+            ok_aux1b: 0.5.0
             ok_dk1b: 0.4.7
             ok_dk5b: 0.4.7
             ok_gr1b: 0.3.8
-            ok_gr3b: 0.4.1
+            ok_gr3b: 0.5.0
+            ok_gr3c: 0.5.0
             ok_hr1b: 0.3.8
-            ok_hs3b: 0.4.6
+            ok_hs3b: 0.5.0
             ok_hs5b: 0.4.3
             ok_hs6b: 0.4.5
             ok_md1b: 0.4.6
-            ok_md3b: 0.3.9
+            ok_md3b: 0.5.0
             ok_mdvrfb: 0.4.3
             ok_me1b: 0.4.7
             ok_tn1b: 0.4.7
+            ok_ht1b: 0.5.0
+            ok_mh2b: 0.5.0
 
 suites:
     all:


### PR DESCRIPTION
Update FW versions for ONOKOM:

HT-1
AUX-1
MH-2
GR-3
MD-3
HS-3
TCL-3

<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
