### PR TITLE
WB-MRWM2: add new signature mrwm2Ge and update testing firmwares to 1.21.3

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1445,6 +1445,7 @@ releases:
             mr2mGe: 1.21.7
             # WB-MRWM2
             mrwm2G: 1.21.2
+            mrwm2Ge: 1.21.3
             # WB-MWAC
             wbmwac: 1.19.2      # на данном таргете на версиях старше 1.19.2 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
             wbmwac_042: 1.19.2  # на данном таргете на версиях старше 1.19.2 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
@@ -1596,7 +1597,8 @@ releases:
             mr6cpGe: 1.21.7
             mr2mGe: 1.21.7
             # WB-MRWM2
-            mrwm2G: 1.21.2
+            mrwm2G: 1.21.3
+            mrwm2Ge: 1.21.3
             # WB-MWAC
             wbmwac: 1.19.2      # на данном таргете на версиях старше 1.19.2 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
             wbmwac_042: 1.19.2  # на данном таргете на версиях старше 1.19.2 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)


### PR DESCRIPTION
Добавлена в stable новая сигнатура для WB-MRWM2 без EEPROM: mrwm2Ge
Обновлены версии тестовых прошивок WB-MRWM2 на 1.21.3
https://github.com/wirenboard/wb-mrwm/pull/13