### PR TITLE
Update WB-MCM8 stable firmware to 1.6.8

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1523,8 +1523,8 @@ releases:
             ledG: 3.5.5
             ledGe: 3.5.6
             # WB-MCM
-            mcm8: 1.6.6
-            mcm8G: 1.6.6
+            mcm8: 1.6.8
+            mcm8G: 1.6.8
             mcm8Ge: 1.6.8
             # WB-MAO
             mao4: 2.4.4         # на данном таргете на версиях старше 2.4.4 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)


### PR DESCRIPTION
Обновление версии стабильной прошивки WB-MCM8 на 1.6.8
https://github.com/wirenboard/wb-mcm/pull/43