### PR TITLE
WB-MS2/MSW4: add new signatures msw5Ge_, msv2Ge_ with stable firmware 4.31.15

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1488,6 +1488,11 @@ releases:
             msw5Gth: 4.31.14
             msw5Gpb: 4.31.14
             msv2Gth: 4.31.14
+            msw5Ge: 4.31.15
+            msw5Geth: 4.31.15
+            msw5Gepb: 4.31.15
+            msv2Ge42nlg: 4.31.15
+            msv2Geth: 4.31.15
             # WB-MD
             mdm3: 2.6.6         # на данном таргете на версиях старше 2.6.6 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
             mdm3_042: 2.6.6     # на данном таргете на версиях старше 2.6.6 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
@@ -1642,6 +1647,11 @@ releases:
             msw5Gth: 4.31.14
             msw5Gpb: 4.31.14
             msv2Gth: 4.31.14
+            msw5Ge: 4.31.15
+            msw5Geth: 4.31.15
+            msw5Gepb: 4.31.15
+            msv2Ge42nlg: 4.31.15
+            msv2Geth: 4.31.15
             # WB-MD
             mdm3: 2.6.6         # на данном таргете на версиях старше 2.6.6 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)
             mdm3_042: 2.6.6     # на данном таргете на версиях старше 2.6.6 прошивка перестала помещаться в 25K (32K FLASH - 4K bootloader - 3 flashfs)


### PR DESCRIPTION
Добавлены в stable сигнатуры для новых датчиков MS2 и MSW4 без EEPROM: msw5Ge, msw5Geth, msw5Gepb, msv2Ge42nlg, msv2Geth
Версия прошивки 4.31.15
https://github.com/wirenboard/wb-ms/pull/245