### PR TITLE
wb-scenarios version up to 1.5.0

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -143,7 +143,7 @@ releases:
             wb-nm-helper: 1.36.0
             wb-rules: 2.34.0
             wb-rules-system: 1.12.5
-            wb-scenarios: 1.4.0
+            wb-scenarios: 1.5.0
             wb-suite: 1.19.8
             wb-update-manager: 1.3.7
             wb-update-notifier: 0.1.0

--- a/releases.yaml
+++ b/releases.yaml
@@ -108,7 +108,7 @@ releases:
             wb-ec-firmware: 2.0.4
             wb-essential: 1.19.8                                       
             wb-firmware-realtek: 1.0.3
-            wb-homeui-backend: 2.117.11
+            wb-homeui-backend: 2.117.11-wb100
             wb-hwconf-manager: 1.67.1
             wb-knxd-config: 1.1.6
             wb-mb-explorer: 1.2.9
@@ -124,7 +124,7 @@ releases:
             wb-mqtt-db: 2.9.1
             wb-mqtt-db-cli: 1.4.8
             wb-mqtt-gpio: 2.16.2
-            wb-mqtt-homeui: 2.117.11
+            wb-mqtt-homeui: 2.117.11-wb100
             wb-mqtt-iec104: 1.1.14
             wb-mqtt-knx: 1.13.4
             wb-mqtt-logs: 1.5.4


### PR DESCRIPTION
1. Поднимаем версию wb-scenarios в стабильном релизе до 1.5.0 https://github.com/wirenboard/wb-scenarios/pull/44, в ней, сценарии скрыты в меню "конфигурационные файлы".
2. Поднимаем версию wb-homeui-backend и wb-mqtt-homeui до 2.117.11-wb100, в ней сценарии переехали в основное меню слева. https://github.com/wirenboard/homeui/pull/795
[задача в Ютрек](https://wirenboard.youtrack.cloud/issue/INT-472/Perenesti-menyu-scenariev-v-stabilnyj-2507)
