### PR TITLE
Revert "Add `co2_sens_ns8: MF1.03D` firmware"

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1758,8 +1758,6 @@ releases:
             # WB-UPS
             ups-v3: 1.0.1
             ups-v3-dlg2: 1.0.2
-            # Component firmwares
-            co2_sens_ns8: MF1.01D
             # ONOKOM
             ok_tcl1b: 0.5.2
             ok_tcl3b: 0.5.2
@@ -1922,8 +1920,6 @@ releases:
             # WB-UPS
             ups-v3: 1.0.1
             ups-v3-dlg2: 1.0.2
-            # Component firmwares
-            co2_sens_ns8: MF1.03D
             # ONOKOM
             ok_tcl1b: 0.5.2
             ok_tcl3b: 0.5.2


### PR DESCRIPTION
Reverts wirenboard/wb-releases#981

Сломалась сборка master из-за другого расширения файла, откатываем и потом разберемся