### PR TITLE
wb-2507: revert wb-cloud-agent to v1.5.14 actually

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -98,7 +98,7 @@ releases:
             telegraf-wb-cloud-agent: 1.29.1-wb2
             wb-ble-tesliot: 1.1.3
             wb-cc2652p-flasher: 1.0.0
-            wb-cloud-agent: 1.6.2
+            wb-cloud-agent: 1.6.2-wb100
             wb-configs: 3.41.0
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.10.0


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
видели 3 случая, что при обновлении на wb-2507, отваливается облако
странное - надо разбираться

=> откатим версию (внутри 1.5.14 по факту)
