### PR TITLE
Update stable firmware for WB-MSW4 to 4.34.1

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1689,12 +1689,12 @@ releases:
             msw3G419th: 4.32.0
             msw3Gc: 4.32.0
             msw3G419L: 4.32.0
-            msw5G: 4.33.0
+            msw5G: 4.34.1
             msw5GL: 4.32.0
             msw5Gth: 4.32.0
             msw5Gpb: 4.32.0
             msv2Gth: 4.32.0
-            msw5Ge: 4.33.0
+            msw5Ge: 4.34.1
             msw5Geth: 4.32.0
             msw5Gepb: 4.32.0
             msv2Ge42nlg: 4.32.0
@@ -1853,12 +1853,12 @@ releases:
             msw3G419th: 4.34.0
             msw3Gc: 4.34.0
             msw3G419L: 4.34.0
-            msw5G: 4.34.0
+            msw5G: 4.34.1
             msw5GL: 4.34.0
             msw5Gth: 4.34.0
             msw5Gpb: 4.34.0
             msv2Gth: 4.34.0
-            msw5Ge: 4.34.0
+            msw5Ge: 4.34.1
             msw5Geth: 4.34.0
             msw5Gepb: 4.34.0
             msv2Ge42nlg: 4.34.0


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-ms/pull/254
Сразу в стейбл, т.к. фикс.
4.34.0 - изменения не значительные (регистр сброса настроек), пусть тоже в стейбл перейдет