### PR TITLE
bump-wb-cloud-agent to v1.6.5

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -98,7 +98,7 @@ releases:
             telegraf-wb-cloud-agent: 1.29.1-wb2
             wb-ble-tesliot: 1.1.3
             wb-cc2652p-flasher: 1.0.0
-            wb-cloud-agent: 1.6.2-wb100
+            wb-cloud-agent: 1.6.5
             wb-configs: 3.41.0
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.10.0


### PR DESCRIPTION
wb-cloud-agent 1.6.5 branch
https://github.com/wirenboard/wb-cloud-agent/commit/83e40b4e34a3c7bd8a5d47530f27695664358f7b
wb-cloud-agent 1.6.2-wb100
https://github.com/wirenboard/wb-releases/commit/fdfd5a3fcaa46bf00e38ae6d60779b9a5f5ee40e
