### PR TITLE
feat: add zigbee2mqtt-2.1.1 to release 2507

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -155,6 +155,7 @@ releases:
             z-way4wb: '1.4'
             zbw: 1.2-wb1
             zigbee2mqtt: 2.5.1-wb101
+            zigbee2mqtt-2.1.1: 2.1.1-wb101
             zigbee2mqtt-1.18.1: 1.18.1-wb103
 
         wb6/bullseye:


### PR DESCRIPTION
Сейчас по какой то причине в релиз 2507 не добавлен пакет zigbee2mqtt-2.1.1
Мы его в мае зафиксировали с Николаем, но он почему то не выкатился в релиз
