### PR TITLE
Update WB-MAI6 stable and testing to 2.1.5

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1756,8 +1756,8 @@ releases:
             mao4Ge-C: 2.6.4
             # WB-MAI
             wb-mai-v10: 1.3.1
-            wb-mai6: 2.1.4
-            wb-mai6-15: 2.1.4
+            wb-mai6: 2.1.5
+            wb-mai6-15: 2.1.5
             # WB-MIO
             mio: 1.6.7
             mioGe: 1.6.7
@@ -1929,8 +1929,8 @@ releases:
             mao4Ge-C: 2.6.4
             # WB-MAI
             wb-mai-v10: 1.3.1
-            wb-mai6: 2.1.4
-            wb-mai6-15: 2.1.4
+            wb-mai6: 2.1.5
+            wb-mai6-15: 2.1.5
             # WB-MIO
             mio: 1.7.0
             mioGe: 1.7.0


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-mai6/pull/25
Сразу в stable, т.к. багфикс