### PR TITLE
Update stable firmware for WB-UPS to 1.1.0

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1767,8 +1767,8 @@ releases:
             refu: 1.4.7
             refuGe: 1.4.7
             # WB-UPS
-            ups-v3: 1.0.1
-            ups-v3-dlg2: 1.0.2
+            ups-v3: 1.1.0
+            ups-v3-dlg2: 1.1.0
             # Component firmwares
             co2_sens_ns8: MF1.03D
             # ONOKOM


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-releases/pull/1001