### PR TITLE
wb-2602: wb-utils v4.27.6 -> v4.27.7; wb-configs v3.50.0 -> v3.50.1

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -104,7 +104,7 @@ releases:
             wb-ble-tesliot: 1.1.3
             wb-cc2652p-flasher: 1.1.0
             wb-cloud-agent: 1.6.12
-            wb-configs: 3.50.0
+            wb-configs: 3.50.1
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.11.0
             wb-device-manager: 1.25.4
@@ -153,7 +153,7 @@ releases:
             wb-suite: 1.20.6
             wb-update-manager: 1.3.7
             wb-update-notifier: 0.1.0
-            wb-utils: 4.27.6
+            wb-utils: 4.27.7
             wb-welrok: 0.0.20
             wb-zigbee2mqtt: 1.4.1
             webif: '1.5'


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
в ребейзе убута обнаружили корнер-кейс, который отловили наши стенды => поправил, надо бекпортировать