### PR TITLE
wb-2602: wb-update-manager 1.3.7 → 1.4.0, wb-mqtt-metrics 0.3.8 → 0.5.0

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -89,9 +89,9 @@ releases:
             python3-umodbus: 1.0.4-1+wb1
             python3-wb-common: 2.2.6
             python3-wb-mcu-fw-updater: 1.14.3
-            python3-wb-mqtt-metrics: 0.3.8
+            python3-wb-mqtt-metrics: 0.5.0
             python3-wb-nm-helper: 1.37.1
-            python3-wb-update-manager: 1.3.7
+            python3-wb-update-manager: 1.4.0
             python3-zpl: 0.1.10-wb101
             rapidscada: 6.4.4-1
             serial-tool: 1.2.4
@@ -135,7 +135,7 @@ releases:
             wb-mqtt-knx: 1.13.4
             wb-mqtt-logs: 1.5.5
             wb-mqtt-mbgate: 1.8.8
-            wb-mqtt-metrics: 0.3.8
+            wb-mqtt-metrics: 0.5.0
             wb-mqtt-opcua: 1.2.1
             wb-mqtt-rfblinds: 1.0.4
             wb-mqtt-serial: 2.224.0-wb103
@@ -151,7 +151,7 @@ releases:
             wb-rules-system: 1.13.1
             wb-scenarios: 1.7.1
             wb-suite: 1.20.6
-            wb-update-manager: 1.3.7
+            wb-update-manager: 1.4.0
             wb-update-notifier: 0.1.0
             wb-utils: 4.27.7
             wb-welrok: 0.0.20


### PR DESCRIPTION
После перевода python3-wb-update-manager и python3-wb-mqtt-metrics в transitional dummy не работает даунгрейд с тестинга на стейбл:
```sh
The following packages have unmet dependencies:
 wb-update-manager : Breaks: python3-wb-update-manager (< 1.4.0)
E: Unmet dependencies. Try 'apt --fix-broken install' with no packages (or specify a solution).
```

* https://github.com/wirenboard/wb-mqtt-metrics/pull/20
* https://github.com/wirenboard/wb-update-manager/pull/48
* https://github.com/wirenboard/wb-mqtt-metrics/pull/19
* https://github.com/wirenboard/wb-update-manager/pull/47