### PR TITLE
bump wb-cloud-agent version and del telegraf

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -102,7 +102,7 @@ releases:
             task-wb-common-pkgs: 1.20.6
             wb-ble-tesliot: 1.1.3
             wb-cc2652p-flasher: 1.1.0
-            wb-cloud-agent: 1.7.0
+            wb-cloud-agent: 1.7.1
             wb-configs: 3.50.1
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.11.0
@@ -299,7 +299,7 @@ releases:
             task-wb-common-pkgs: 1.19.8
             wb-ble-tesliot: 1.1.3
             wb-cc2652p-flasher: 1.0.0
-            wb-cloud-agent: 1.7.0
+            wb-cloud-agent: 1.7.1
             wb-configs: 3.41.0
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.10.1
@@ -503,7 +503,7 @@ releases:
             task-wb-common-pkgs: 1.19.0
             wb-ble-tesliot: 1.1.1
             wb-cc2652p-flasher: 1.0.0
-            wb-cloud-agent: 1.7.0
+            wb-cloud-agent: 1.7.1
             wb-configs: 3.35.0
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.10.0
@@ -727,7 +727,7 @@ releases:
             task-wb-common-pkgs: 1.19.0
             wb-ble-tesliot: 1.1.1
             wb-cc2652p-flasher: 1.0.0
-            wb-cloud-agent: 1.7.0
+            wb-cloud-agent: 1.7.1
             wb-configs: 3.33.0
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.9.0
@@ -945,7 +945,7 @@ releases:
             u-boot-tools-wb: 2:2021.10+wb1.7.3
             wb-ble-tesliot: 1.1.1
             wb-cc2652p-flasher: 1.0.0
-            wb-cloud-agent: 1.7.0
+            wb-cloud-agent: 1.7.1
             wb-configs: 3.28.0-wb100
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.8.2

--- a/releases.yaml
+++ b/releases.yaml
@@ -100,10 +100,9 @@ releases:
             tailscale: 1.94.1
             task-wb-base-system: 1.20.6
             task-wb-common-pkgs: 1.20.6
-            telegraf-wb-cloud-agent: 1.29.1-wb4
             wb-ble-tesliot: 1.1.3
             wb-cc2652p-flasher: 1.1.0
-            wb-cloud-agent: 1.6.12
+            wb-cloud-agent: 1.7.0
             wb-configs: 3.50.1
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.11.0
@@ -298,10 +297,9 @@ releases:
             tailscale: 1.84.0
             task-wb-base-system: 1.19.8
             task-wb-common-pkgs: 1.19.8
-            telegraf-wb-cloud-agent: 1.29.1-wb4
             wb-ble-tesliot: 1.1.3
             wb-cc2652p-flasher: 1.0.0
-            wb-cloud-agent: 1.6.12
+            wb-cloud-agent: 1.7.0
             wb-configs: 3.41.0
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.10.1
@@ -503,10 +501,9 @@ releases:
             tailscale: 1.82.0
             task-wb-base-system: 1.19.0
             task-wb-common-pkgs: 1.19.0
-            telegraf-wb-cloud-agent: 1.29.1-wb2
             wb-ble-tesliot: 1.1.1
             wb-cc2652p-flasher: 1.0.0
-            wb-cloud-agent: 1.5.12
+            wb-cloud-agent: 1.7.0
             wb-configs: 3.35.0
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.10.0
@@ -728,10 +725,9 @@ releases:
             tailscale: 1.78.1
             task-wb-base-system: 1.19.0
             task-wb-common-pkgs: 1.19.0
-            telegraf-wb-cloud-agent: 1.29.1-wb2
             wb-ble-tesliot: 1.1.1
             wb-cc2652p-flasher: 1.0.0
-            wb-cloud-agent: 1.5.11
+            wb-cloud-agent: 1.7.0
             wb-configs: 3.33.0
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.9.0
@@ -946,11 +942,10 @@ releases:
             tailscale: 1.76.6
             task-wb-base-system: 1.19.0
             task-wb-common-pkgs: 1.19.0
-            telegraf-wb-cloud-agent: 1.29.1-wb2
             u-boot-tools-wb: 2:2021.10+wb1.7.3
             wb-ble-tesliot: 1.1.1
             wb-cc2652p-flasher: 1.0.0
-            wb-cloud-agent: 1.5.7
+            wb-cloud-agent: 1.7.0
             wb-configs: 3.28.0-wb100
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.8.2
@@ -1557,7 +1552,6 @@ releases:
             python3-modbus-utils-rpc: 1.0.1
             rapidscada: 6.0.2-1
             ss-dev: 2.0-1.43.4-2+wb1
-            telegraf-wb-cloud-agent: 1.28.4
             wb-cloud-agent: 1.2.5-wb102
             wb-cloud-agent-curl: 1.2.5-wb102
             wb-demo-kit-configs: 1.6.1
@@ -2180,7 +2174,6 @@ staging:
         - "rapidscada"
         - "serial-tool"
         - "tailscale"
-        - "telegraf-wb-cloud-agent"
         - "tm-cpps"
         - "u-boot-tools-wb"
         - "u-boot-wb?"

--- a/releases.yaml
+++ b/releases.yaml
@@ -301,7 +301,7 @@ releases:
             telegraf-wb-cloud-agent: 1.29.1-wb4
             wb-ble-tesliot: 1.1.3
             wb-cc2652p-flasher: 1.0.0
-            wb-cloud-agent: 1.6.12
+            wb-cloud-agent: 1.7.1
             wb-configs: 3.41.0
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.10.1

--- a/releases.yaml
+++ b/releases.yaml
@@ -301,7 +301,7 @@ releases:
             telegraf-wb-cloud-agent: 1.29.1-wb4
             wb-ble-tesliot: 1.1.3
             wb-cc2652p-flasher: 1.0.0
-            wb-cloud-agent: 1.7.1
+            wb-cloud-agent: 1.6.12
             wb-configs: 3.41.0
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.10.1
@@ -506,7 +506,7 @@ releases:
             telegraf-wb-cloud-agent: 1.29.1-wb2
             wb-ble-tesliot: 1.1.1
             wb-cc2652p-flasher: 1.0.0
-            wb-cloud-agent: 1.7.1
+            wb-cloud-agent: 1.5.12
             wb-configs: 3.35.0
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.10.0
@@ -731,7 +731,7 @@ releases:
             telegraf-wb-cloud-agent: 1.29.1-wb2
             wb-ble-tesliot: 1.1.1
             wb-cc2652p-flasher: 1.0.0
-            wb-cloud-agent: 1.7.1
+            wb-cloud-agent: 1.5.11
             wb-configs: 3.33.0
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.9.0
@@ -950,7 +950,7 @@ releases:
             u-boot-tools-wb: 2:2021.10+wb1.7.3
             wb-ble-tesliot: 1.1.1
             wb-cc2652p-flasher: 1.0.0
-            wb-cloud-agent: 1.7.1
+            wb-cloud-agent: 1.5.7
             wb-configs: 3.28.0-wb100
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.8.2

--- a/releases.yaml
+++ b/releases.yaml
@@ -100,6 +100,7 @@ releases:
             tailscale: 1.94.1
             task-wb-base-system: 1.20.6
             task-wb-common-pkgs: 1.20.6
+            telegraf-wb-cloud-agent: 1.29.1-wb4
             wb-ble-tesliot: 1.1.3
             wb-cc2652p-flasher: 1.1.0
             wb-cloud-agent: 1.7.1
@@ -297,6 +298,7 @@ releases:
             tailscale: 1.84.0
             task-wb-base-system: 1.19.8
             task-wb-common-pkgs: 1.19.8
+            telegraf-wb-cloud-agent: 1.29.1-wb4
             wb-ble-tesliot: 1.1.3
             wb-cc2652p-flasher: 1.0.0
             wb-cloud-agent: 1.7.1
@@ -501,6 +503,7 @@ releases:
             tailscale: 1.82.0
             task-wb-base-system: 1.19.0
             task-wb-common-pkgs: 1.19.0
+            telegraf-wb-cloud-agent: 1.29.1-wb2
             wb-ble-tesliot: 1.1.1
             wb-cc2652p-flasher: 1.0.0
             wb-cloud-agent: 1.7.1
@@ -725,6 +728,7 @@ releases:
             tailscale: 1.78.1
             task-wb-base-system: 1.19.0
             task-wb-common-pkgs: 1.19.0
+            telegraf-wb-cloud-agent: 1.29.1-wb2
             wb-ble-tesliot: 1.1.1
             wb-cc2652p-flasher: 1.0.0
             wb-cloud-agent: 1.7.1
@@ -942,6 +946,7 @@ releases:
             tailscale: 1.76.6
             task-wb-base-system: 1.19.0
             task-wb-common-pkgs: 1.19.0
+            telegraf-wb-cloud-agent: 1.29.1-wb2
             u-boot-tools-wb: 2:2021.10+wb1.7.3
             wb-ble-tesliot: 1.1.1
             wb-cc2652p-flasher: 1.0.0
@@ -1552,6 +1557,7 @@ releases:
             python3-modbus-utils-rpc: 1.0.1
             rapidscada: 6.0.2-1
             ss-dev: 2.0-1.43.4-2+wb1
+            telegraf-wb-cloud-agent: 1.28.4
             wb-cloud-agent: 1.2.5-wb102
             wb-cloud-agent-curl: 1.2.5-wb102
             wb-demo-kit-configs: 1.6.1
@@ -2176,6 +2182,7 @@ staging:
         - "rapidscada"
         - "serial-tool"
         - "tailscale"
+        - "telegraf-wb-cloud-agent"
         - "tm-cpps"
         - "u-boot-tools-wb"
         - "u-boot-wb?"


### PR DESCRIPTION
- Поднимает версию пакета агента для релиза 2602 и 2507 до 1.7.1

Почему не для всех?
Прилично народу сидит на старых версиях релизов и не хочет уходить с них, а новый агент всё же хочется докатить до них, но это не безопасно т.к. можем что то сломать, подтверили @vdromanov  и @sikmir 
<img width="692" height="557" alt="image" src="https://github.com/user-attachments/assets/41dc638f-7da5-4beb-ac90-33831101e4ec" />

[1.6.13](https://github.com/wirenboard/wb-cloud-agent/pull/65)
[1.6.14](https://github.com/wirenboard/wb-cloud-agent/pull/66)
[1.7.0](https://github.com/wirenboard/wb-cloud-agent/pull/67)
[1.7.1](https://github.com/wirenboard/wb-cloud-agent/pull/68)