### PR TITLE
wb-mqtt-serial: update wb-2606 <- 2.248.1, wb-2602 <- 2.224.0-wb106

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -139,7 +139,7 @@ releases:
             wb-mqtt-metrics: 0.5.0
             wb-mqtt-opcua: 1.3.1
             wb-mqtt-rfblinds: 1.0.4
-            wb-mqtt-serial: 2.248.0
+            wb-mqtt-serial: 2.248.1
             wb-mqtt-smartbus: '1.2'
             wb-mqtt-smartweb: 1.5.0
             wb-mqtt-snmp: 1.5.0
@@ -346,7 +346,7 @@ releases:
             wb-mqtt-metrics: 0.5.0
             wb-mqtt-opcua: 1.2.1
             wb-mqtt-rfblinds: 1.0.4
-            wb-mqtt-serial: 2.224.0-wb105
+            wb-mqtt-serial: 2.224.0-wb106
             wb-mqtt-smartbus: '1.2'
             wb-mqtt-smartweb: 1.4.11
             wb-mqtt-snmp: 1.4.1


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-mqtt-serial/pull/1175
https://github.com/wirenboard/wb-mqtt-serial/pull/1176