### PR TITLE
wb-2606: wb-ec-firmware: 2.1.1

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -110,7 +110,7 @@ releases:
             wb-device-manager: 1.25.4
             wb-diag-collect: 1.9.6
             wb-dt-overlays: 1.7.0
-            wb-ec-firmware: 2.2.0
+            wb-ec-firmware: 2.1.1
             wb-essential: 1.20.9
             wb-firmware-realtek: 1.0.4
             wb-homeui-backend: 2.208.1


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
Пока не берем версию 2.2.0 в релиз, позже обновим сами