### PR TITLE
bump wb-cloud-agent to 1.7.2 version

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -103,7 +103,7 @@ releases:
             wb-ble-tesliot: 1.1.3
             wb-cc2652p-flasher: 1.1.0
             wb-cli: 1.8.5
-            wb-cloud-agent: 1.7.1
+            wb-cloud-agent: 1.7.2
             wb-configs: 3.50.2
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.11.0
@@ -311,7 +311,7 @@ releases:
             telegraf-wb-cloud-agent: 1.29.1-wb4
             wb-ble-tesliot: 1.1.3
             wb-cc2652p-flasher: 1.1.0
-            wb-cloud-agent: 1.7.1
+            wb-cloud-agent: 1.7.2
             wb-configs: 3.50.1
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.11.0
@@ -509,7 +509,7 @@ releases:
             telegraf-wb-cloud-agent: 1.29.1-wb4
             wb-ble-tesliot: 1.1.3
             wb-cc2652p-flasher: 1.0.0
-            wb-cloud-agent: 1.7.1
+            wb-cloud-agent: 1.7.2
             wb-configs: 3.41.0
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.10.1


### PR DESCRIPTION
[70](https://github.com/wirenboard/wb-cloud-agent/pull/70)