### PR TITLE
wb-2606: bump wb-hwconf-manager, linux-image-wb8

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -114,7 +114,7 @@ releases:
             wb-essential: 1.20.9
             wb-firmware-realtek: 1.0.4
             wb-homeui-backend: 2.208.1
-            wb-hwconf-manager: 1.71.5
+            wb-hwconf-manager: 1.71.6
             wb-knxd-config: 1.1.6
             wb-mb-explorer: 1.2.9
             wb-mcu-fw-flasher: 1.6.1
@@ -194,10 +194,10 @@ releases:
 
             arm-trusted-firmware: 2.10.0+dfsg-1+wb2
             e2fsprogs-udeb: 1.46.2-2+wb1
-            linux-headers-wb8: 6.8.0-wb157
-            linux-image-wb8: 6.8.0-wb157
-            linux-libc-dev: 6.8.0-wb157
-            wb-bootlet-wb8x: 6.8.0-wb157-fs1.5.5-deb11-202604271428
+            linux-headers-wb8: 6.8.0-wb158
+            linux-image-wb8: 6.8.0-wb158
+            linux-libc-dev: 6.8.0-wb158
+            wb-bootlet-wb8x: 6.8.0-wb158-fs1.5.5-deb11-202604271428
             u-boot-wb8: 2:2025.04+wb1.1.3
             u-boot-tools-wb: 2:2025.04+wb1.1.3
             tm-cpps: '16402'


### PR DESCRIPTION
* https://github.com/wirenboard/linux/pull/355
* https://github.com/wirenboard/wb-hwconf-manager/pull/155
