### PR TITLE
Add Docker CE and related pkgs

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -2401,7 +2401,8 @@ staging:
         - "zbw"
         - "zigbee2mqtt*"
 
-        - "docker-ce*"
+        - "docker-ce"
+        - "docker-ce-cli"
         - "containerd.io"
         - "docker-compose-plugin"
 

--- a/releases.yaml
+++ b/releases.yaml
@@ -2401,6 +2401,10 @@ staging:
         - "zbw"
         - "zigbee2mqtt*"
 
+        - "docker-ce*"
+        - "containerd.io"
+        - "docker-compose-plugin"
+
         - "gir1.2-mbim-1.0"  # bullseye backport
         - "gir1.2-qmi-1.0"   # bullseye backport
         - "gir1.2-qrtr-1.0"  # bullseye backport


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->

[INT-1034](https://wirenboard.youtrack.cloud/issue/INT-1034/wb-docker.-Novosti-dodelki)

Добавляет перепакованый [docker-ce](https://github.com/wirenboard/wb-docker) и переложенные docker-ce-cli, containerd.io и docker-compose-plugin

