### PR TITLE
Update mge_v3 version to 1.1.2(stable) and 1.2.0(dev)

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -2003,7 +2003,7 @@ releases:
             ups-v3: 1.3.1
             ups-v3-dlg2: 1.3.1
             # WB-MGE
-            mge_v3: 1.1.0
+            mge_v3: 1.1.2
             # WB-DALI
             dali3G: 1.0.0
             # WB-WALLSWITCH-ESL
@@ -2201,7 +2201,7 @@ releases:
             ups-v3: 1.3.2
             ups-v3-dlg2: 1.3.2
             # WB-MGE
-            mge_v3: 1.1.1
+            mge_v3: 1.2.0
             # WB-DALI
             dali3G: 1.0.0
             # WB-WALLSWITCH-ESL


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
Дев: https://github.com/wirenboard/wb-mge/pull/88
Стейб — там выпилили из существующего main все защиты прошивки, PR-а не было.