### PR TITLE
bump wb-cloud-agent version

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -103,7 +103,7 @@ releases:
             wb-ble-tesliot: 1.1.3
             wb-cc2652p-flasher: 1.1.0
             wb-cli: 1.8.5
-            wb-cloud-agent: 1.7.2
+            wb-cloud-agent: 1.8.1
             wb-configs: 3.50.2
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.11.0

--- a/releases.yaml
+++ b/releases.yaml
@@ -103,7 +103,7 @@ releases:
             wb-ble-tesliot: 1.1.3
             wb-cc2652p-flasher: 1.1.0
             wb-cli: 1.8.5
-            wb-cloud-agent: 1.8.1
+            wb-cloud-agent: 1.8.1-wb100
             wb-configs: 3.50.2
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.11.0


### PR DESCRIPTION
Поднимаю `wb-cloud-agent` в релизе 2606 (bullseye) с `1.7.2` до бэкпорт-версии `1.8.1-wb100`.

Бэкпорт фичи из 1.8.1 (коллектор метрик рендерится из шаблона, вшитого в пакет) в bullseye, без Debian-13 порта — отсюда суффикс `-wb100` и зависимость от curl без версии.

* https://github.com/wirenboard/wb-cloud-agent/pull/74 — бэкпорт в release/wb-2606
* https://github.com/wirenboard/wb-cloud-agent/pull/73 — исходная фича
