### PR TITLE
mcm8: revert testing firmware to 1.9.1

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -2173,7 +2173,7 @@ releases:
             ledG: 3.7.1
             ledGe: 3.7.1
             # WB-MCM
-            mcm8: 1.10.0
+            mcm8: 1.9.1
             mcm8G: 1.10.0
             mcm8Ge: 1.10.0
             mcm8Gec: 1.10.0


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
Нашли багу для старого STM устройства, пока откатим версию