### PR TITLE
Update wb-mcm8 testing firmware versions to 1.10.1

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -2174,10 +2174,10 @@ releases:
             ledGe: 3.7.1
             # WB-MCM
             mcm8: 1.9.1
-            mcm8G: 1.10.0
-            mcm8Ge: 1.10.0
-            mcm8Gec: 1.10.0
-            mcm8Gehv: 1.10.0
+            mcm8G: 1.10.1
+            mcm8Ge: 1.10.1
+            mcm8Gec: 1.10.1
+            mcm8Gehv: 1.10.1
             # WB-MAO
             mao4G: 2.8.1
             mao4G-C: 2.8.1


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-mcm/pull/54