### PR TITLE
wb-2606-trixie-transition: wb-update-manager: 1.4.0-upgrade3 -> 1.4.0-upgrade4

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1863,8 +1863,8 @@ releases:
 
     wb-2606-trixie-transition:
         packages-common-trixie-transition: &packages-wb-2606-trixie-transition
-            python3-wb-update-manager: 1.4.0-upgrade3
-            wb-update-manager: 1.4.0-upgrade3
+            python3-wb-update-manager: 1.4.0-upgrade4
+            wb-update-manager: 1.4.0-upgrade4
 
         wb6/bullseye:
             <<: *packages-wb-2606-armhf-wb6-bullseye


### PR DESCRIPTION
- https://github.com/wirenboard/wb-update-manager/pull/51
