### PR TITLE
Update WB-UPS testing firmware to 1.4.0

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -2198,8 +2198,8 @@ releases:
             refu: 1.5.1
             refuGe: 1.5.1
             # WB-UPS
-            ups-v3: 1.3.2
-            ups-v3-dlg2: 1.3.2
+            ups-v3: 1.4.0
+            ups-v3-dlg2: 1.4.0
             # WB-MGE
             mge_v3: 1.1.1
             # WB-DALI


### PR DESCRIPTION
https://github.com/wirenboard/wb-ups/pull/24