### PR TITLE
Enable bootloaders presence check and release-versions publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
 publishRelease releasesFilename: 'releases.yaml',
                aptlyConfig: 'release-aptly-config',
+               hasBootloaders: true,
                triggerCheckStaging: true

--- a/releases.yaml
+++ b/releases.yaml
@@ -2734,17 +2734,6 @@ suites:
         testing: _bootloaders_testing
         unstable: _bootloaders_testing
 
-        wb-2207: _bootloaders_stable
-        wb-2304-70549e24: _bootloaders_stable
-        wb-2307-cb8ea449: _bootloaders_stable
-        wb-2307-a70ab64c: _bootloaders_stable
-        wb-2407-e1d931dd: _bootloaders_stable
-        wb-2407-a70ab64c: _bootloaders_stable
-        wb-2410-cb8ea449: _bootloaders_stable
-        wb-2501-cb8ea449: _bootloaders_stable
-        wb-2507-cb8ea449: _bootloaders_stable
-
-
 
 targets:
     wb8/trixie:

--- a/releases.yaml
+++ b/releases.yaml
@@ -2729,6 +2729,21 @@ suites:
         wb-2501-cb8ea449: _firmwares_stable
         wb-2507-cb8ea449: _firmwares_stable
 
+    bootloaders:
+        stable: _bootloaders_stable
+        testing: _bootloaders_testing
+        unstable: _bootloaders_testing
+
+        wb-2207: _bootloaders_stable
+        wb-2304-70549e24: _bootloaders_stable
+        wb-2307-cb8ea449: _bootloaders_stable
+        wb-2307-a70ab64c: _bootloaders_stable
+        wb-2407-e1d931dd: _bootloaders_stable
+        wb-2407-a70ab64c: _bootloaders_stable
+        wb-2410-cb8ea449: _bootloaders_stable
+        wb-2501-cb8ea449: _bootloaders_stable
+        wb-2507-cb8ea449: _bootloaders_stable
+
 
 
 targets:


### PR DESCRIPTION
Связанные изменения:
- wirenboard/wb-ci-tools#52 — `wbci-fw --kind {firmwares,bootloaders}`: проверка наличия загрузчиков на S3 + генерация `boot/by-signature/release-versions.yaml`.
- wirenboard/jenkins-pipeline-lib#172 — стейджи `Check bootloaders` / `Deploy bootloaders list` в общем `publishRelease`.