### PR TITLE
wb-2606: wb7 & 8 u-boot v1.1.5-wb100 -> 1.1.5-wb101

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -184,8 +184,8 @@ releases:
             linux-headers-wb7: 5.10.35-wb182
             linux-libc-dev: 5.10.35-wb182
             wb-bootlet-wb7x: 5.10.35-wb182-fs1.5.4-deb11-202512150209
-            u-boot-wb7: 2:2025.04+wb1.1.5-wb100
-            u-boot-tools-wb: 2:2025.04+wb1.1.5-wb100
+            u-boot-wb7: 2:2025.04+wb1.1.5-wb101
+            u-boot-tools-wb: 2:2025.04+wb1.1.5-wb101
             tm-cpps: '16304'
             mplc4-wirenboard7: 1.3.6.21566
 
@@ -198,8 +198,8 @@ releases:
             linux-image-wb8: 6.8.0-wb159
             linux-libc-dev: 6.8.0-wb159
             wb-bootlet-wb8x: 6.8.0-wb159-fs1.5.5-deb11-202604271428
-            u-boot-wb8: 2:2025.04+wb1.1.5-wb100
-            u-boot-tools-wb: 2:2025.04+wb1.1.5-wb100
+            u-boot-wb8: 2:2025.04+wb1.1.5-wb101
+            u-boot-tools-wb: 2:2025.04+wb1.1.5-wb101
             tm-cpps: '16402'
             wb-hdmi: 1.20.9
             wb-hdmi-wayland: 1.20.9


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/u-boot-private/pull/82
вот ето надо занести в stable, чтобы производство производило