### PR TITLE
Bump mosquitto to 2.0.20-1-wb103 in wb-2606 stable release

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -39,10 +39,10 @@ releases:
             libmm-glib0: 1.20.0-1~bpo11+1-wb108
             libmodbus-dev: 3.1.6-wb2
             libmodbus5: 3.1.6-wb2
-            libmosquitto-dev: 2.0.20-1-wb102
-            libmosquitto1: 2.0.20-1-wb102
-            libmosquittopp-dev: 2.0.20-1-wb102
-            libmosquittopp1: 2.0.20-1-wb102
+            libmosquitto-dev: 2.0.20-1-wb103
+            libmosquitto1: 2.0.20-1-wb103
+            libmosquittopp-dev: 2.0.20-1-wb103
+            libmosquittopp1: 2.0.20-1-wb103
             libnm-dev: 1.42.4-1~bpo11+1-wb103
             libnm0: 1.42.4-1~bpo11+1-wb103
             libqmi-glib-dev: 1.32.0-1~bpo11+1
@@ -68,9 +68,9 @@ releases:
             modemmanager: 1.20.0-1~bpo11+1-wb108
             modemmanager-dev: 1.20.0-1~bpo11+1-wb108
             modemmanager-doc: 1.20.0-1~bpo11+1-wb108
-            mosquitto: 2.0.20-1-wb102
-            mosquitto-clients: 2.0.20-1-wb102
-            mosquitto-dev: 2.0.20-1-wb102
+            mosquitto: 2.0.20-1-wb103
+            mosquitto-clients: 2.0.20-1-wb103
+            mosquitto-dev: 2.0.20-1-wb103
             mplc4-oni-plc-w: 1.3.6.21566
             mqtt-tools: 1.4.5
             mqttui: 0.23.0-1


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/mosquitto/pull/6