### PR TITLE
Add wb-node-red 1.0.0 to testing (wb-2606-trixie-transition)

### DIFF
--- a/git-sources.yaml
+++ b/git-sources.yaml
@@ -111,6 +111,7 @@ by-package:
     wb-mqtt-zabbix: "https://github.com/wirenboard/wb-mqtt-zabbix"
     wb-mqtt-zway: "https://github.com/wirenboard/wb-mqtt-zway"
     wb-nm-helper: "https://github.com/wirenboard/wb-nm-helper"
+    wb-node-red: "https://github.com/wirenboard/wb-node-red"
     wb-rules-system: "https://github.com/wirenboard/wb-rules-system"
     wb-rules: "https://github.com/wirenboard/wb-rules"
     wb-scenarios: "https://github.com/wirenboard/wb-scenarios"

--- a/releases.yaml
+++ b/releases.yaml
@@ -1864,6 +1864,7 @@ releases:
     wb-2606-trixie-transition:
         packages-common-trixie-transition: &packages-wb-2606-trixie-transition
             python3-wb-update-manager: 1.4.0-upgrade7
+            wb-node-red: 1.0.0
             wb-update-manager: 1.4.0-upgrade7
 
         wb6/bullseye:


### PR DESCRIPTION
Новый пакет: **wb-node-red 1.0.0** — Node-RED как нативный deb-пакет за логином homeui.

- Реализация: wirenboard/wb-node-red#3 (INT-622)
- Добавлен в `wb-2606-trixie-transition` (testing/unstable для wb6/wb7/wb8 bullseye); на trixie-таргетах testing = `@unstable.latest`, там пакет появится автоматически.
- `git-sources.yaml` — ссылка на репозиторий для changelog.

Замечание: редактор станет доступен из веба только с `wb-mqtt-homeui >= 2.235.4` (механизм service-gates; у нас в Recommends). В trixie-transition сейчас 2.208.1 — пакет установится и сервис заработает, но гейт/пункт меню появятся после обновления homeui в testing. Проверено e2e на стендах с homeui 2.242.4.
