### PR TITLE
Update WB-MAP testing firmware to 2.14.0

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -2154,26 +2154,26 @@ releases:
             mdm3G26: 2.12.1
             mdm3G26e: 2.12.1
             # WB-MAP
-            map3e_36: 2.13.1
-            map3e_031f6: 2.13.1
-            map3eG: 2.13.1
-            map3h51: 2.13.1
-            map6s: 2.13.1
-            map6s51: 2.13.1
-            map6se: 2.13.1
-            map12eG: 2.13.1
-            map12h: 2.13.1
-            map3eG16: 2.13.1
-            map3evG16: 2.13.1
-            map6seG16: 2.13.1
-            map6sG16: 2.13.1
-            map6semG16: 2.13.1
-            map3eG16e: 2.13.1
-            map3evG16e: 2.13.1
-            map6semG16e: 2.13.1
-            map12eGe: 2.13.1
-            map3etG16e: 2.13.1
-            map3eG16e2: 2.13.1
+            map3e_36: 2.14.0
+            map3e_031f6: 2.14.0
+            map3eG: 2.14.0
+            map3h51: 2.14.0
+            map6s: 2.14.0
+            map6s51: 2.14.0
+            map6se: 2.14.0
+            map12eG: 2.14.0
+            map12h: 2.14.0
+            map3eG16: 2.14.0
+            map3evG16: 2.14.0
+            map6seG16: 2.14.0
+            map6sG16: 2.14.0
+            map6semG16: 2.14.0
+            map3eG16e: 2.14.0
+            map3evG16e: 2.14.0
+            map6semG16e: 2.14.0
+            map12eGe: 2.14.0
+            map3etG16e: 2.14.0
+            map3eG16e2: 2.14.0
             # WB-MRGB
             mrgbwG: 3.9.0
             ledG: 3.9.0


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-map/pull/145