### PR TITLE
wb-2606: libateccssl1.1: 0.2.6-wb101 -> 0.2.6-wb102

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -26,7 +26,7 @@ releases:
             knxd: 0.14.74-1+wb100
             knxd-dev: 0.14.74-1+wb100
             knxd-tools: 0.14.74-1+wb100
-            libateccssl1.1: 0.2.6-wb101
+            libateccssl1.1: 0.2.6-wb102
             libcom-err2: 1.46.2-2+wb1
             libext2fs-dev: 1.46.2-2+wb1
             libext2fs2: 1.46.2-2+wb1


### PR DESCRIPTION
https://github.com/wirenboard/cryptoauth-openssl-engine/pull/15
