### PR TITLE
wb-2606: u-boot-wb8: 2:2025.04+wb1.1.5-wb101 → wb102

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -198,8 +198,8 @@ releases:
             linux-image-wb8: 6.8.0-wb160
             linux-libc-dev: 6.8.0-wb160
             wb-bootlet-wb8x: 6.8.0-wb160-fs1.5.5-deb11-202604271428
-            u-boot-wb8: 2:2025.04+wb1.1.5-wb101
-            u-boot-tools-wb: 2:2025.04+wb1.1.5-wb101
+            u-boot-wb8: 2:2025.04+wb1.1.5-wb102
+            u-boot-tools-wb: 2:2025.04+wb1.1.5-wb102
             tm-cpps: '16402'
             wb-hdmi: 1.20.9
             wb-hdmi-wayland: 1.20.9


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Бекпорт в стабильный релиз фичи с прокидыванием типа и размера RAM в device tree, просили в тестировании

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**

