### PR TITLE
Update ONOKOM firmwares

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -2025,12 +2025,12 @@ releases:
             ok_grp3b: 26.07.01
             ok_grp3c: 26.07.01
             ok_hr1b: 26.07.01
-            ok_hs3b: 26.07.01
-            ok_hs3c: 26.07.01
+            ok_hs3b: 26.07.02
+            ok_hs3c: 26.07.02
             ok_hs5b: 26.07.01
             ok_hs6b: 26.07.01
             ok_hsvrfb: 26.07.01
-            ok_md1b: 26.07.01
+            ok_md1b: 26.07.02
             ok_md3b: 26.07.01
             ok_md3c: 26.07.01
             ok_mdvrfb: 26.07.01
@@ -2038,14 +2038,14 @@ releases:
             ok_cgvrfb: 26.07.01
             ok_cgvrfc: 26.07.01
             ok_me1b: 26.07.01
-            ok_tn1b: 26.07.01
+            ok_tn1b: 26.07.02
             ok_ht1b: 26.07.01
             ok_mh2b: 26.07.01
             ok_auxvrfc: 26.07.01
             ok_cm1d: 26.07.01
             ok_cm3d: 26.07.01
-            ok_gr5b: 26.07.01
-            ok_tb1b: 26.07.01
+            ok_gr5b: 26.07.02
+            ok_tb1b: 26.07.02
             ok_air3c: 26.07.01
 
             # Deprecated
@@ -2230,12 +2230,12 @@ releases:
             ok_grp3b: 26.07.01
             ok_grp3c: 26.07.01
             ok_hr1b: 26.07.01
-            ok_hs3b: 26.07.01
-            ok_hs3c: 26.07.01
+            ok_hs3b: 26.07.02
+            ok_hs3c: 26.07.02
             ok_hs5b: 26.07.01
             ok_hs6b: 26.07.01
             ok_hsvrfb: 26.07.01
-            ok_md1b: 26.07.01
+            ok_md1b: 26.07.02
             ok_md3b: 26.07.01
             ok_md3c: 26.07.01
             ok_mdvrfb: 26.07.01
@@ -2243,14 +2243,14 @@ releases:
             ok_cgvrfb: 26.07.01
             ok_cgvrfc: 26.07.01
             ok_me1b: 26.07.01
-            ok_tn1b: 26.07.01
+            ok_tn1b: 26.07.02
             ok_ht1b: 26.07.01
             ok_mh2b: 26.07.01
             ok_auxvrfc: 26.07.01
             ok_cm1d: 26.07.01
             ok_cm3d: 26.07.01
-            ok_gr5b: 26.07.01
-            ok_tb1b: 26.07.01
+            ok_gr5b: 26.07.02
+            ok_tb1b: 26.07.02
             ok_air3c: 26.07.01
 
             # Deprecated


### PR DESCRIPTION
bump up version for:
GR-5
HS-3
MD-1
TB-1
TN-1