### PR TITLE
Add new fw signature: mao4Gesic

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1986,6 +1986,7 @@ releases:
             mao4Ge: 2.8.1
             mao4Ge-C: 2.8.1
             mao4Gemz: 2.8.2
+            mao4Gesic: 2.10.1
             # WB-MAI
             wb-mai-v10: 1.3.1
             wb-mai6: 2.4.2
@@ -2191,6 +2192,7 @@ releases:
             mao4Ge: 2.10.0
             mao4Ge-C: 2.10.0
             mao4Gemz: 2.10.0
+            mao4Gesic: 2.10.1
             # WB-MAI
             wb-mai-v10: 1.3.1
             wb-mai6: 2.4.2
@@ -2397,6 +2399,7 @@ releases:
             mao4Ge: 1.5.7
             mao4Ge-C: 1.5.5
             mao4Gemz: 1.5.7
+            mao4Gesic: 1.5.7
             # WB-MAI
             wb-mai-v10: 1.3.0
             wb-mai6: 1.5.7
@@ -2606,6 +2609,7 @@ releases:
             mao4Ge: 1.5.7
             mao4Ge-C: 1.5.5
             mao4Gemz: 1.5.7
+            mao4Gesic: 1.5.7
             # WB-MAI
             wb-mai-v10: 1.3.0
             wb-mai6: 1.5.7


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
Новая сигнатура `mao4Gesic` — WB-MAO4 новой ревизии платы с уменьшенными
конденсаторами на входах (22 nF вместо 2.2 µF), чтобы работал быстрый энкодер.
Прошивка и MQTT-шаблон совпадают с `mao4Ge`; отдельная сигнатура нужна, чтобы
в дальнейшем точечно доставлять изменения на эту ревизию.

https://github.com/wirenboard/wb-mao4/pull/47

Загрузчик — тот же таргет `NOEEPROM_LEDA4LOW_U2_GD32E230`, версия `1.5.7`
как у `mao4Ge`.
