### PR TITLE
wb-2606: pick up SOFT-7211 empty-config fixes

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -104,7 +104,7 @@ releases:
             wb-cc2652p-flasher: 1.1.0
             wb-cli: 1.8.5
             wb-cloud-agent: 1.8.1-wb100
-            wb-configs: 3.50.2
+            wb-configs: 3.50.2-wb100
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.11.0
             wb-device-manager: 1.25.4
@@ -113,7 +113,7 @@ releases:
             wb-ec-firmware: 2.1.1
             wb-essential: 1.20.9
             wb-firmware-realtek: 1.0.4
-            wb-homeui-backend: 2.208.1-wb101
+            wb-homeui-backend: 2.208.1-wb102
             wb-hwconf-manager: 1.71.6
             wb-knxd-config: 1.1.6
             wb-mb-explorer: 1.2.9
@@ -131,15 +131,15 @@ releases:
             wb-mqtt-db: 2.9.3
             wb-mqtt-db-cli: 1.4.8
             wb-mqtt-gpio: 2.16.3
-            wb-mqtt-homeui: 2.208.1-wb101
+            wb-mqtt-homeui: 2.208.1-wb102
             wb-mqtt-iec104: 1.2.0
             wb-mqtt-knx: 1.13.4
             wb-mqtt-logs: 1.5.5
             wb-mqtt-mbgate: 1.8.8
             wb-mqtt-metrics: 0.5.0
-            wb-mqtt-opcua: 1.3.1-wb100
+            wb-mqtt-opcua: 1.3.1-wb101
             wb-mqtt-rfblinds: 1.0.4
-            wb-mqtt-serial: 2.248.1-wb102
+            wb-mqtt-serial: 2.248.1-wb103
             wb-mqtt-smartbus: '1.2'
             wb-mqtt-smartweb: 1.5.0
             wb-mqtt-snmp: 1.5.0

--- a/releases.yaml
+++ b/releases.yaml
@@ -104,7 +104,7 @@ releases:
             wb-cc2652p-flasher: 1.1.0
             wb-cli: 1.8.5
             wb-cloud-agent: 1.8.1-wb100
-            wb-configs: 3.50.2-wb100
+            wb-configs: 3.50.2+wb100
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.11.0
             wb-device-manager: 1.25.4

--- a/releases.yaml
+++ b/releases.yaml
@@ -104,7 +104,7 @@ releases:
             wb-cc2652p-flasher: 1.1.0
             wb-cli: 1.8.5
             wb-cloud-agent: 1.8.1-wb100
-            wb-configs: 3.50.2+wb100
+            wb-configs: 3.50.2-wb100
             wb-daemon-watchdogs: '1.1'
             wb-demo-kit-configs: 1.11.0
             wb-device-manager: 1.25.4


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

фиксы пустых конфигов после отключения питания:

- wb-configs 3.50.2-wb100 — wirenboard/wb-configs#248
- wb-mqtt-homeui, wb-homeui-backend 2.208.1-wb102 — wirenboard/homeui#1190 
- wb-mqtt-serial 2.248.1-wb103 — wirenboard/wb-mqtt-serial#1214 
- wb-mqtt-opcua 1.3.1-wb101 — wirenboard/wb-mqtt-opcua#40 

Мержить после мержа и сборки пакетных PR.

___________________________________
**Что поменялось для пользователей:**

Отключение питания больше не оставляет контроллер на wb-2606 с пустыми или частичными конфигами

___________________________________
**Как проверял/а:**



