### PR TITLE
wb-2606: dimmer templates (wb-mqtt-serial 2.248.1-wb105) + dimmers stable firmware versions

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -139,7 +139,7 @@ releases:
             wb-mqtt-metrics: 0.5.0
             wb-mqtt-opcua: 1.3.1-wb101
             wb-mqtt-rfblinds: 1.0.4
-            wb-mqtt-serial: 2.248.1-wb103
+            wb-mqtt-serial: 2.248.1-wb104
             wb-mqtt-smartbus: '1.2'
             wb-mqtt-smartweb: 1.5.0
             wb-mqtt-snmp: 1.5.0

--- a/releases.yaml
+++ b/releases.yaml
@@ -139,7 +139,7 @@ releases:
             wb-mqtt-metrics: 0.5.0
             wb-mqtt-opcua: 1.3.1-wb101
             wb-mqtt-rfblinds: 1.0.4
-            wb-mqtt-serial: 2.248.1-wb104
+            wb-mqtt-serial: 2.248.1-wb105
             wb-mqtt-smartbus: '1.2'
             wb-mqtt-smartweb: 1.5.0
             wb-mqtt-snmp: 1.5.0

--- a/releases.yaml
+++ b/releases.yaml
@@ -1947,8 +1947,8 @@ releases:
             msw5Geth: 4.37.2
             msw5Gepb: 4.37.2
             # WB-MD
-            mdm3G26: 2.11.1
-            mdm3G26e: 2.11.1
+            mdm3G26: 2.12.1
+            mdm3G26e: 2.12.1
             # WB-MAP
             map3e_36: 2.13.1
             map3e_031f6: 2.13.1
@@ -1971,9 +1971,9 @@ releases:
             map3etG16e: 2.13.1
             map3eG16e2: 2.13.1
             # WB-MRGB
-            mrgbwG: 3.7.1
-            ledG: 3.7.1
-            ledGe: 3.7.1
+            mrgbwG: 3.9.0
+            ledG: 3.9.0
+            ledGe: 3.9.0
             # WB-MCM
             mcm8: 1.10.2
             mcm8G: 1.10.2
@@ -1981,11 +1981,11 @@ releases:
             mcm8Gec: 1.10.2
             mcm8Gehv: 1.10.2
             # WB-MAO
-            mao4G: 2.8.1
-            mao4G-C: 2.8.1
-            mao4Ge: 2.8.1
-            mao4Ge-C: 2.8.1
-            mao4Gemz: 2.8.2
+            mao4G: 2.10.0
+            mao4G-C: 2.10.0
+            mao4Ge: 2.10.0
+            mao4Ge-C: 2.10.0
+            mao4Gemz: 2.10.0
             mao4Gesic: 2.10.1
             # WB-MAI
             wb-mai-v10: 1.3.1


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Переводим доработки диммеров в stable ([FW-1291](https://wirenboard.youtrack.cloud/issue/FW-1291)), а так же поддержка бэкпорта в текущий stable обновлённых шаблонов диммеров.

___________________________________
**Что поменялось для пользователей:**

Добавлена поддержка энкодеров, удалённого плавного управления, возможность задать шаг диммирования короткими нажатиями, дублирующие каналы управления с автовключением.

Новые шаблоны привязаны к новым версиям прошивок, устройства со старыми прошивками остаются на старых шаблонах, поведение существующих установок не меняется.

___________________________________
**Как проверял/а:**

Полностью (юнит-тесты, стенды, testing релиз)

---
Мержить только после того, как wirenboard/wb-mqtt-serial#1216 влит и Jenkins собрал `2.248.1-wb105`.

