### PR TITLE
wb-2606: backport WB-MCM8HV buttons template

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -139,7 +139,7 @@ releases:
             wb-mqtt-metrics: 0.5.0
             wb-mqtt-opcua: 1.3.1-wb101
             wb-mqtt-rfblinds: 1.0.4
-            wb-mqtt-serial: 2.248.1-wb103
+            wb-mqtt-serial: 2.248.1-wb104
             wb-mqtt-smartbus: '1.2'
             wb-mqtt-smartweb: 1.5.0
             wb-mqtt-snmp: 1.5.0


### PR DESCRIPTION
Обновление версии `wb-mqtt-serial` в релизе `wb-2606` (stable) после бекпорта шаблона WB-MCM8HV с поддержкой кнопок.

`2.248.1-wb103` → `2.248.1-wb104`

**Связанные PR:**
- Бекпорт в релизную ветку: https://github.com/wirenboard/wb-mqtt-serial/pull/1217
- Исходный PR в master: https://github.com/wirenboard/wb-mqtt-serial/pull/1194

**Зачем:** устройство WB-MCM8HV ещё не выпущено, шаблон нужен в stable к моменту выхода — без бекпорта он приехал бы туда только со следующим релизом.
