### PR TITLE
mge_v3: stable 1.1.1 + testing 1.2.0

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -2004,7 +2004,7 @@ releases:
             ups-v3: 1.4.1
             ups-v3-dlg2: 1.4.1
             # WB-MGE
-            mge_v3: 1.1.0
+            mge_v3: 1.1.1
             # WB-DALI
             dali3G: 1.0.0
             dali3G15: 1.0.2
@@ -2210,7 +2210,7 @@ releases:
             ups-v3: 1.4.1
             ups-v3-dlg2: 1.4.1
             # WB-MGE
-            mge_v3: 1.1.1
+            mge_v3: 1.2.0
             # WB-DALI
             dali3G: 1.0.2
             dali3G15: 1.0.2


### PR DESCRIPTION
WB-MGE (mge_v3):
- stable: 1.1.0 → 1.1.1 (в testing с 12.05.2026, отлежалась заметно дольше 3 недель)
- testing: 1.1.1 → 1.2.0 (новый UI, разделение настроек на Network / Serial Ports / TCP gateway)

Файлы на s3: fw/by-signature/mge_v3/main/1.1.1.bin, fw/by-signature/mge_v3/main/1.2.0.bin