### PR TITLE
Update dimmers stable firmware versions: WB-MDM3 2.12.1, WB-LED/WB-MRGBW-D 3.9.0, WB-MAO4 2.10.0

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1947,8 +1947,8 @@ releases:
             msw5Geth: 4.37.2
             msw5Gepb: 4.37.2
             # WB-MD
-            mdm3G26: 2.11.1
-            mdm3G26e: 2.11.1
+            mdm3G26: 2.12.1
+            mdm3G26e: 2.12.1
             # WB-MAP
             map3e_36: 2.13.1
             map3e_031f6: 2.13.1
@@ -1971,9 +1971,9 @@ releases:
             map3etG16e: 2.13.1
             map3eG16e2: 2.13.1
             # WB-MRGB
-            mrgbwG: 3.7.1
-            ledG: 3.7.1
-            ledGe: 3.7.1
+            mrgbwG: 3.9.0
+            ledG: 3.9.0
+            ledGe: 3.9.0
             # WB-MCM
             mcm8: 1.10.2
             mcm8G: 1.10.2
@@ -1981,11 +1981,11 @@ releases:
             mcm8Gec: 1.10.2
             mcm8Gehv: 1.10.2
             # WB-MAO
-            mao4G: 2.8.1
-            mao4G-C: 2.8.1
-            mao4Ge: 2.8.1
-            mao4Ge-C: 2.8.1
-            mao4Gemz: 2.8.2
+            mao4G: 2.10.0
+            mao4G-C: 2.10.0
+            mao4Ge: 2.10.0
+            mao4Ge-C: 2.10.0
+            mao4Gemz: 2.10.0
             mao4Gesic: 2.10.1
             # WB-MAI
             wb-mai-v10: 1.3.1


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Переводим прошивки диммеров в stable ([FW-1291](https://wirenboard.youtrack.cloud/issue/FW-1291)).

Связанное: бэкпорт шаблонов диммеров в stable-релиз wb-2606 — https://github.com/wirenboard/wb-mqtt-serial/pull/1216 и https://github.com/wirenboard/wb-releases/pull/1266.

___________________________________
**Что поменялось для пользователей:**

Добавлена поддержка энкодеров, удалённого плавного управления, возможность задать шаг диммирования короткими нажатиями, дублирующие каналы управления с автовключением.

___________________________________
**Как проверял/а:**

Полностью (юнит-тесты, стенды, testing релиз)
