### PR TITLE
mge_v3: testing 1.3.0

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -2210,7 +2210,7 @@ releases:
             ups-v3: 1.4.1
             ups-v3-dlg2: 1.4.1
             # WB-MGE
-            mge_v3: 1.1.1
+            mge_v3: 1.3.0
             # WB-DALI
             dali3G: 1.0.2
             dali3G15: 1.0.2


### PR DESCRIPTION
Переводит WB-MGE v.3 в канал testing на прошивку 1.3.0.

Прошивка собрана из main (`50c2b41`, PR wirenboard/wb-mge#91), сборка Jenkins зелёная целиком, бинарь уже выложен: `fw/by-signature/mge_v3/main/1.3.0.bin` отдаётся с облака.

Что в версии: анализатор шины Modbus с захватом RS-485 через веб-интерфейс, кэш карты регистров с отдачей по Modbus TCP, режим прозрачного повторителя между портами, регистры устройства на Unit ID 255, обновление прошивки из выбранного канала в один клик. Запись для чейнджлога вики уже подготовлена.

Stable намеренно оставлен на 1.1.0 — по релизному циклу сначала testing, перевод в stable по результатам понедельничного check-testing-firmwares.

Заменяет #1270 и #1193: они заводились на 1.1.1/1.2.0 и устарели, закрыты в пользу этого PR.