### PR TITLE
wb2606: update wb-mqtt-serial version to 2.248.1-wb106

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -139,7 +139,7 @@ releases:
             wb-mqtt-metrics: 0.5.0
             wb-mqtt-opcua: 1.3.1-wb101
             wb-mqtt-rfblinds: 1.0.4
-            wb-mqtt-serial: 2.248.1-wb105
+            wb-mqtt-serial: 2.248.1-wb106
             wb-mqtt-smartbus: '1.2'
             wb-mqtt-smartweb: 1.5.0
             wb-mqtt-snmp: 1.5.0


### PR DESCRIPTION
<!--
Добавь сюда ссылки на те PR, с которыми добавлены изменения в пакеты.
Github автоматически свяжет этот PR с ними, так удобней трекать, что
фактически попало в релиз.
-->
https://github.com/wirenboard/wb-mqtt-serial/pull/1225