### PR TITLE
Update dimmer testing firmwares to 2.12.3/3.9.2/2.10.3

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -2153,8 +2153,8 @@ releases:
             msw5Geth: 4.38.0
             msw5Gepb: 4.38.0
             # WB-MD
-            mdm3G26: 2.12.1
-            mdm3G26e: 2.12.1
+            mdm3G26: 2.12.3
+            mdm3G26e: 2.12.3
             # WB-MAP
             map3e_36: 2.14.0
             map3e_031f6: 2.14.0
@@ -2177,9 +2177,9 @@ releases:
             map3etG16e: 2.14.0
             map3eG16e2: 2.14.0
             # WB-MRGB
-            mrgbwG: 3.9.0
-            ledG: 3.9.0
-            ledGe: 3.9.0
+            mrgbwG: 3.9.2
+            ledG: 3.9.2
+            ledGe: 3.9.2
             # WB-MCM
             mcm8: 1.11.1
             mcm8G: 1.11.1
@@ -2187,12 +2187,12 @@ releases:
             mcm8Gec: 1.11.1
             mcm8Gehv: 1.11.1
             # WB-MAO
-            mao4G: 2.10.0
-            mao4G-C: 2.10.0
-            mao4Ge: 2.10.0
-            mao4Ge-C: 2.10.0
-            mao4Gemz: 2.10.0
-            mao4Gesic: 2.10.1
+            mao4G: 2.10.3
+            mao4G-C: 2.10.3
+            mao4Ge: 2.10.3
+            mao4Ge-C: 2.10.3
+            mao4Gemz: 2.10.3
+            mao4Gesic: 2.10.3
             # WB-MAI
             wb-mai-v10: 1.3.1
             wb-mai6: 2.4.2


### PR DESCRIPTION
https://github.com/wirenboard/wb-md/pull/74
https://github.com/wirenboard/wb-mrgb/pull/122
https://github.com/wirenboard/wb-mao4/pull/52
