### PR TITLE
Update ONOKOM firmwares

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -2013,36 +2013,36 @@ releases:
             # Component firmwares
             co2_sens_ns8: MF1.03D
             # ONOKOM
-            ok_tcl1b: 26.07.01
-            ok_tcl3b: 26.07.01
-            ok_tcl3c: 26.07.01
-            ok_tcl6b: 26.07.01
-            ok_aux1b: 26.07.01
-            ok_dk1b: 26.07.01
-            ok_dk5b: 26.07.01
-            ok_gr1b: 26.07.01
-            ok_gr3b: 26.07.01
-            ok_gr3c: 26.07.01
+            ok_tcl1b: 26.08.01
+            ok_tcl3b: 26.08.01
+            ok_tcl3c: 26.08.01
+            ok_tcl6b: 26.08.01
+            ok_aux1b: 26.08.01
+            ok_dk1b: 26.08.01
+            ok_dk5b: 26.08.01
+            ok_gr1b: 26.08.01
+            ok_gr3b: 26.08.01
+            ok_gr3c: 26.08.01
             ok_grp3b: 26.07.01
             ok_grp3c: 26.07.01
-            ok_hr1b: 26.07.01
+            ok_hr1b: 26.08.01
             ok_hs3b: 26.07.02
             ok_hs3c: 26.07.02
-            ok_hs5b: 26.07.01
-            ok_hs6b: 26.07.01
-            ok_hsvrfb: 26.07.01
+            ok_hs5b: 26.08.01
+            ok_hs6b: 26.08.01
+            ok_hsvrfb: 26.08.01
             ok_md1b: 26.07.02
-            ok_md3b: 26.07.01
-            ok_md3c: 26.07.01
-            ok_mdvrfb: 26.07.01
-            ok_mdvrfc: 26.07.01
-            ok_cgvrfb: 26.07.01
-            ok_cgvrfc: 26.07.01
-            ok_me1b: 26.07.01
+            ok_md3b: 26.08.01
+            ok_md3c: 26.08.01
+            ok_mdvrfb: 26.08.01
+            ok_mdvrfc: 26.08.01
+            ok_cgvrfb: 26.08.01
+            ok_cgvrfc: 26.08.01
+            ok_me1b: 26.08.01
             ok_tn1b: 26.07.02
-            ok_ht1b: 26.07.01
-            ok_mh2b: 26.07.01
-            ok_auxvrfc: 26.07.01
+            ok_ht1b: 26.08.01
+            ok_mh2b: 26.08.01
+            ok_auxvrfc: 26.08.01
             ok_cm1d: 26.07.01
             ok_cm3d: 26.07.01
             ok_gr5b: 26.07.02
@@ -2219,36 +2219,36 @@ releases:
             # Component firmwares
             co2_sens_ns8: MF1.03D
             # ONOKOM
-            ok_tcl1b: 26.07.01
-            ok_tcl3b: 26.07.01
-            ok_tcl3c: 26.07.01
-            ok_tcl6b: 26.07.01
-            ok_aux1b: 26.07.01
-            ok_dk1b: 26.07.01
-            ok_dk5b: 26.07.01
-            ok_gr1b: 26.07.01
-            ok_gr3b: 26.07.01
-            ok_gr3c: 26.07.01
+            ok_tcl1b: 26.08.01
+            ok_tcl3b: 26.08.01
+            ok_tcl3c: 26.08.01
+            ok_tcl6b: 26.08.01
+            ok_aux1b: 26.08.01
+            ok_dk1b: 26.08.01
+            ok_dk5b: 26.08.01
+            ok_gr1b: 26.08.01
+            ok_gr3b: 26.08.01
+            ok_gr3c: 26.08.01
             ok_grp3b: 26.07.01
             ok_grp3c: 26.07.01
-            ok_hr1b: 26.07.01
+            ok_hr1b: 26.08.01
             ok_hs3b: 26.07.02
             ok_hs3c: 26.07.02
-            ok_hs5b: 26.07.01
-            ok_hs6b: 26.07.01
-            ok_hsvrfb: 26.07.01
+            ok_hs5b: 26.08.01
+            ok_hs6b: 26.08.01
+            ok_hsvrfb: 26.08.01
             ok_md1b: 26.07.02
-            ok_md3b: 26.07.01
-            ok_md3c: 26.07.01
-            ok_mdvrfb: 26.07.01
-            ok_mdvrfc: 26.07.01
-            ok_cgvrfb: 26.07.01
-            ok_cgvrfc: 26.07.01
-            ok_me1b: 26.07.01
+            ok_md3b: 26.08.01
+            ok_md3c: 26.08.01
+            ok_mdvrfb: 26.08.01
+            ok_mdvrfc: 26.08.01
+            ok_cgvrfb: 26.08.01
+            ok_cgvrfc: 26.08.01
+            ok_me1b: 26.08.01
             ok_tn1b: 26.07.02
-            ok_ht1b: 26.07.01
-            ok_mh2b: 26.07.01
-            ok_auxvrfc: 26.07.01
+            ok_ht1b: 26.08.01
+            ok_mh2b: 26.08.01
+            ok_auxvrfc: 26.08.01
             ok_cm1d: 26.07.01
             ok_cm3d: 26.07.01
             ok_gr5b: 26.07.02


### PR DESCRIPTION
bump up version for:
TCL-1
TCL-3
TCL-6
AUX-1
DK-1
DK-5
GR-1
GR-3
HR-1
HS-5
HS-6
HS-VRF
MD-3
MD-VRF
CG-VRF
ME-1
HT-1
MH-2
AUX-VRF
