### PR TITLE
wb-2606-trixie-transition: bump wb-update-manager

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1863,8 +1863,8 @@ releases:
 
     wb-2606-trixie-transition:
         packages-common-trixie-transition: &packages-wb-2606-trixie-transition
-            python3-wb-update-manager: 1.4.0-upgrade9
-            wb-update-manager: 1.4.0-upgrade9
+            python3-wb-update-manager: 1.4.0-upgrade10
+            wb-update-manager: 1.4.0-upgrade10
 
         wb6/bullseye:
             <<: *packages-wb-2606-armhf-wb6-bullseye


### PR DESCRIPTION
* https://github.com/wirenboard/wb-update-manager/pull/58
